### PR TITLE
feat: count all clubs in a single query

### DIFF
--- a/pages/api/indexer/stats/count_addrs.ts
+++ b/pages/api/indexer/stats/count_addrs.ts
@@ -28,7 +28,7 @@ export default async function handler(
     .aggregate([
       {
         $match: {
-          _chain_valid_to: null,
+          "_chain.valid_to": null,
           creation_date: {
             $gte: new Date(sinceTime),
           },

--- a/pages/api/indexer/stats/count_club_domains.ts
+++ b/pages/api/indexer/stats/count_club_domains.ts
@@ -78,7 +78,7 @@ export default async function handler(
                                         'input': '$domain',
                                         'regex': /^\d{4}\.stark$/
                                       }
-                                    }, '10k', 'nothing'
+                                    }, '10k', 'none'
                                   ]
                                 }
                               ]

--- a/pages/api/indexer/stats/count_club_domains.ts
+++ b/pages/api/indexer/stats/count_club_domains.ts
@@ -48,30 +48,30 @@ export default async function handler(
                     {
                       '$regexMatch': {
                         'input': '$domain',
-                        'regex': /^.{2}\.stark$/
+                        'regex': /^\d{2}\.stark$/
                       }
-                    }, 'two_letters', {
+                    }, '99', {
                       '$cond': [
                         {
                           '$regexMatch': {
                             'input': '$domain',
-                            'regex': /^.{3}\.stark$/
+                            'regex': /^.{2}\.stark$/
                           }
-                        }, 'three_letters', {
+                        }, 'two_letters', {
                           '$cond': [
                             {
                               '$regexMatch': {
                                 'input': '$domain',
-                                'regex': /^\d{2}\.stark$/
+                                'regex': /^\d{3}\.stark$/
                               }
-                            }, '99', {
+                            }, '999', {
                               '$cond': [
                                 {
                                   '$regexMatch': {
                                     'input': '$domain',
-                                    'regex': /^\d{3}\.stark$/
+                                    'regex': /^.{3}\.stark$/
                                   }
-                                }, '999', {
+                                }, 'three_letters', {
                                   '$cond': [
                                     {
                                       '$regexMatch': {

--- a/pages/api/indexer/stats/count_club_domains.ts
+++ b/pages/api/indexer/stats/count_club_domains.ts
@@ -23,12 +23,12 @@ export default async function handler(
   const { db } = await connectToDatabase();
   const domainCollection = db.collection("domains");
 
-  const output = (
+  const dbOutput = (
     await domainCollection
       .aggregate([
         {
           $match: {
-            _chain_valid_to: null,
+            "_chain.valid_to": null,
             creation_date: {
               $gte: new Date(beginTime),
             },
@@ -105,7 +105,37 @@ export default async function handler(
         },
       ])
       .toArray()
-  ).map((doc) => ({ club: doc.club, count: doc.count }))
+  );
+
+
+  let _99;
+  let _999;
+  for (const doc of dbOutput) {
+    if (doc.club === "99")
+      _99 = doc.count;
+    else if (doc.club === "999")
+      _999 = doc.count;
+  }
+
+  const output = [];
+  for (const doc of dbOutput) {
+    if (doc.club === "two_letters") {
+      output.push({
+        club: doc.club,
+        count: doc.count + _99,
+      })
+    } else if (doc.club === "three_letters") {
+      output.push({
+        club: doc.club,
+        count: doc.count + _999,
+      })
+    } else {
+      output.push({
+        club: doc.club,
+        count: doc.count,
+      });
+    }
+  }
 
   res
     .setHeader("cache-control", "max-age=30")

--- a/pages/api/indexer/stats/count_created.ts
+++ b/pages/api/indexer/stats/count_created.ts
@@ -31,7 +31,7 @@ export default async function handler(
           .aggregate([
             {
               $match: {
-                _chain_valid_to: null,
+                "_chain.valid_to": null,
                 creation_date: {
                   $gte: new Date(beginTime),
                   $lte: new Date(endTime),

--- a/pages/api/indexer/stats/count_renewed.ts
+++ b/pages/api/indexer/stats/count_renewed.ts
@@ -31,7 +31,7 @@ export default async function handler(
           .aggregate([
             {
               $match: {
-                _chain_valid_to: null,
+                "_chain.valid_to": null,
                 renewal_date: {
                   $gte: new Date(beginTime),
                   $lte: new Date(endTime),

--- a/pages/api/indexer/stats/expired_club_domains.ts
+++ b/pages/api/indexer/stats/expired_club_domains.ts
@@ -34,42 +34,42 @@ export default async function handler(
                 {
                   '$regexMatch': {
                     'input': '$domain',
-                    'regex': new RegExp('^.\.stark$')
+                    'regex': /^.\.stark$/
                   }
                 }, 'single_letter', {
                   '$cond': [
                     {
                       '$regexMatch': {
                         'input': '$domain',
-                        'regex': new RegExp('^\d{2}\.stark$')
+                        'regex': /^\d{2}\.stark$/
                       }
                     }, '99', {
                       '$cond': [
                         {
                           '$regexMatch': {
                             'input': '$domain',
-                            'regex': new RegExp('^.{2}\.stark$')
+                            'regex': /^.{2}\.stark$/
                           }
                         }, 'two_letters', {
                           '$cond': [
                             {
                               '$regexMatch': {
                                 'input': '$domain',
-                                'regex': new RegExp('^\d{3}\.stark$')
+                                'regex': /^\d{3}\.stark$/
                               }
                             }, '999', {
                               '$cond': [
                                 {
                                   '$regexMatch': {
                                     'input': '$domain',
-                                    'regex': new RegExp('^.{3}\.stark$')
+                                    'regex': /^.{3}\.stark$/
                                   }
                                 }, 'three_letters', {
                                   '$cond': [
                                     {
                                       '$regexMatch': {
                                         'input': '$domain',
-                                        'regex': new RegExp('^\d{4}\.stark$')
+                                        'regex': /^\d{4}\.stark$/
                                       }
                                     }, '10k', 'none'
                                   ]


### PR DESCRIPTION
This pull request allows to query all clubs mint data since a specified timestamp in a single request. It performs a single database call.