### PR TITLE
feat: add id_to_infts

### DIFF
--- a/pages/api/indexer/id_to_infts.ts
+++ b/pages/api/indexer/id_to_infts.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { connectToDatabase } from "../../../lib/mongodb";
+import NextCors from "nextjs-cors";
+import { QueryError } from "../../../types/backTypes";
+
+type IdentityNFT = {
+  contract: string,
+  inft_id: string,
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Array<IdentityNFT> | QueryError>
+) {
+  await NextCors(req, res, {
+    methods: ["GET"],
+    origin: "*",
+    optionsSuccessStatus: 200,
+  });
+  const {
+    query: { id },
+  } = req;
+  const { db } = await connectToDatabase();
+  const domainCollection = db.collection("equipped_infts");
+  const output: Array<IdentityNFT> = [];
+  await domainCollection
+    .find({ starknet_id: id, "_chain.valid_to": null })
+    .forEach((doc) => {
+      output.push({ contract: doc.contract, inft_id: doc.inft_id });
+    });
+
+  res
+    .setHeader("cache-control", "max-age=30")
+    .status(200)
+    .json(output);
+}


### PR DESCRIPTION
This adds an id_to_infts endpoint which returns Identity NFTs equipped by the specified starnetid.

For example, if I query my identity nfts through ``http://localhost:3000/api/indexer/id_to_infts?id=1``, I get:
```json
[{"contract":"0x6f68d51627382d4e8495f69d34a37b77e7feb3e78f19f77a7ab14c4908c15ce","inft_id":"1"}]
```