### PR TITLE
ref: ux improvements

### DIFF
--- a/components/domains/details.tsx
+++ b/components/domains/details.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { FunctionComponent, useEffect, useState } from "react";
-import Link from "next/link";
 import {
   useAddressFromDomain,
   useExpiryFromDomain,
@@ -108,11 +107,14 @@ const Details: FunctionComponent<DetailsProps> = ({ domain }) => {
         />
       )}
       {tokenId && (
-        <Link href={`/identities/${tokenId}`}>
-          <div className={styles.cardCenter}>
-            <p className="text">See owner identity</p>
-          </div>
-        </Link>
+        <div
+          onClick={() =>
+            window.open(`https://www.starknet.id/${domain.concat(".stark")}`)
+          }
+          className={styles.cardCenter}
+        >
+          <p className="text">See owner identity</p>
+        </div>
       )}
       {/* <div className="flex justify-center align-center mt-2">
         <div className="m-2">

--- a/components/domains/details.tsx
+++ b/components/domains/details.tsx
@@ -109,7 +109,7 @@ const Details: FunctionComponent<DetailsProps> = ({ domain }) => {
       {tokenId && (
         <div
           onClick={() =>
-            window.open(`https://www.starknet.id/${domain.concat(".stark")}`)
+            window.open(`https://www.starknet.id/${domain}.stark"`)
           }
           className={styles.cardCenter}
         >

--- a/components/domains/register.tsx
+++ b/components/domains/register.tsx
@@ -11,7 +11,7 @@ import BN from "bn.js";
 import {
   hexToDecimal,
   isHexString,
-  isStarkDomain,
+  isStarkRootDomain,
 } from "../../utils/stringService";
 import { ethers } from "ethers";
 import L1buying_abi from "../../abi/L1/L1Buying_abi.json";
@@ -393,7 +393,7 @@ const Register: FunctionComponent<RegisterProps> = ({
                   duration < 1 ||
                   !targetAddress ||
                   !tokenId ||
-                  !isStarkDomain(domain.concat(".stark"))
+                  !isStarkRootDomain(domain.concat(".stark"))
                 }
               >
                 Register from L1

--- a/components/domains/register.tsx
+++ b/components/domains/register.tsx
@@ -6,7 +6,7 @@ import styles from "../../styles/Home.module.css";
 import { usePricingContract } from "../../hooks/contracts";
 import { useAccount, useStarknetCall } from "@starknet-react/core";
 import { useStarknetExecute } from "@starknet-react/core";
-import { useEncoded } from "../../hooks/naming";
+import { useEncoded, useUpdatedDomainFromAddress } from "../../hooks/naming";
 import BN from "bn.js";
 import { isHexString, isStarkDomain } from "../../utils/stringService";
 import { ethers } from "ethers";
@@ -36,10 +36,11 @@ const Register: FunctionComponent<RegisterProps> = ({
     method: "compute_buy_price",
     args: [encodedDomain, duration * 365],
   });
-  const { account } = useAccount();
+  const { account, address } = useAccount();
   const { execute } = useStarknetExecute({
     calls: callData as any,
   });
+  const hasMainDomain = Boolean(useUpdatedDomainFromAddress(address));
 
   const [domainsMinting, setDomainsMinting] = useState<Map<string, boolean>>(
     new Map()
@@ -62,11 +63,12 @@ const Register: FunctionComponent<RegisterProps> = ({
     }
   }, [account]);
 
+  // Set mulitcalls
   useEffect(() => {
     if (!isAvailable) return;
     const newTokenId: number = Math.floor(Math.random() * 1000000000000);
 
-    if (tokenId != 0) {
+    if (tokenId != 0 && hasMainDomain) {
       setCallData([
         {
           contractAddress: process.env.NEXT_PUBLIC_ETHER_CONTRACT as string,
@@ -89,7 +91,35 @@ const Register: FunctionComponent<RegisterProps> = ({
           ],
         },
       ]);
-    } else {
+    } else if (tokenId != 0 && !hasMainDomain) {
+      setCallData([
+        {
+          contractAddress: process.env.NEXT_PUBLIC_ETHER_CONTRACT as string,
+          entrypoint: "approve",
+          calldata: [
+            process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
+            price,
+            0,
+          ],
+        },
+        {
+          contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
+          entrypoint: "buy",
+          calldata: [
+            new BN(tokenId).toString(10),
+            new BN(encodedDomain).toString(10),
+            new BN(duration * 365).toString(10),
+            0,
+            new BN(targetAddress?.slice(2), 16).toString(10),
+          ],
+        },
+        {
+          contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
+          entrypoint: "set_address_to_domain",
+          calldata: [1, new BN(encodedDomain).toString(10)],
+        },
+      ]);
+    } else if (tokenId === 0 && hasMainDomain) {
       setCallData([
         {
           contractAddress: process.env.NEXT_PUBLIC_ETHER_CONTRACT as string,
@@ -116,6 +146,40 @@ const Register: FunctionComponent<RegisterProps> = ({
             0,
             new BN(targetAddress?.slice(2), 16).toString(10),
           ],
+        },
+      ]);
+    } else if (tokenId === 0 && !hasMainDomain) {
+      setCallData([
+        {
+          contractAddress: process.env.NEXT_PUBLIC_ETHER_CONTRACT as string,
+          entrypoint: "approve",
+          calldata: [
+            process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
+            price,
+            0,
+          ],
+        },
+        {
+          contractAddress: process.env
+            .NEXT_PUBLIC_STARKNETID_CONTRACT as string,
+          entrypoint: "mint",
+          calldata: [new BN(newTokenId).toString(10)],
+        },
+        {
+          contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
+          entrypoint: "buy",
+          calldata: [
+            new BN(newTokenId).toString(10),
+            new BN(encodedDomain).toString(10),
+            new BN(duration * 365).toString(10),
+            0,
+            new BN(targetAddress?.slice(2), 16).toString(10),
+          ],
+        },
+        {
+          contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
+          entrypoint: "set_address_to_domain",
+          calldata: [1, new BN(encodedDomain).toString(10)],
         },
       ]);
     }

--- a/components/domains/register.tsx
+++ b/components/domains/register.tsx
@@ -8,7 +8,11 @@ import { useAccount, useStarknetCall } from "@starknet-react/core";
 import { useStarknetExecute } from "@starknet-react/core";
 import { useEncoded, useUpdatedDomainFromAddress } from "../../hooks/naming";
 import BN from "bn.js";
-import { isHexString, isStarkDomain } from "../../utils/stringService";
+import {
+  hexToDecimal,
+  isHexString,
+  isStarkDomain,
+} from "../../utils/stringService";
 import { ethers } from "ethers";
 import L1buying_abi from "../../abi/L1/L1Buying_abi.json";
 import SelectDomain from "./selectDomains";
@@ -87,7 +91,7 @@ const Register: FunctionComponent<RegisterProps> = ({
             new BN(encodedDomain).toString(10),
             new BN(duration * 365).toString(10),
             0,
-            new BN(targetAddress?.slice(2), 16).toString(10),
+            hexToDecimal(targetAddress ?? ""),
           ],
         },
       ]);
@@ -110,7 +114,7 @@ const Register: FunctionComponent<RegisterProps> = ({
             new BN(encodedDomain).toString(10),
             new BN(duration * 365).toString(10),
             0,
-            new BN(targetAddress?.slice(2), 16).toString(10),
+            hexToDecimal(targetAddress ?? ""),
           ],
         },
         {
@@ -144,7 +148,7 @@ const Register: FunctionComponent<RegisterProps> = ({
             new BN(encodedDomain).toString(10),
             new BN(duration * 365).toString(10),
             0,
-            new BN(targetAddress?.slice(2), 16).toString(10),
+            hexToDecimal(targetAddress ?? ""),
           ],
         },
       ]);
@@ -173,7 +177,7 @@ const Register: FunctionComponent<RegisterProps> = ({
             new BN(encodedDomain).toString(10),
             new BN(duration * 365).toString(10),
             0,
-            new BN(targetAddress?.slice(2), 16).toString(10),
+            hexToDecimal(targetAddress ?? ""),
           ],
         },
         {

--- a/components/domains/selectDomains.tsx
+++ b/components/domains/selectDomains.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import { useAccount } from "@starknet-react/core";
 import React, { FunctionComponent, useEffect, useState } from "react";
-import { hexToFelt } from "../../utils/felt";
+import { hexToDecimal } from "../../utils/stringService";
 
 type SelectDomainProps = {
   tokenId: number;
@@ -28,7 +28,9 @@ const SelectDomain: FunctionComponent<SelectDomainProps> = ({
   useEffect(() => {
     if (account) {
       fetch(
-        `/api/indexer/addr_to_available_ids?addr=${hexToFelt(account.address)}`
+        `/api/indexer/addr_to_available_ids?addr=${hexToDecimal(
+          account.address
+        )}`
       )
         .then((response) => response.json())
         .then((data) => {

--- a/components/identities/actions/changeAddressModal.tsx
+++ b/components/identities/actions/changeAddressModal.tsx
@@ -2,7 +2,7 @@ import { Modal, TextField } from "@mui/material";
 import { useAccount, useStarknetExecute } from "@starknet-react/core";
 import BN from "bn.js";
 import React, { FunctionComponent, useState } from "react";
-import { isHexString } from "../../../utils/stringService";
+import { hexToDecimal, isHexString } from "../../../utils/stringService";
 import styles from "../../../styles/components/wallets.module.css";
 import { stringDecimalToHex } from "../../../utils/felt";
 import Button from "../../UI/button";
@@ -29,10 +29,7 @@ const ChangeAddressModal: FunctionComponent<ChangeAddressModalProps> = ({
   const set_domain_to_address_calls = {
     contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
     entrypoint: "set_domain_to_address",
-    calldata: [
-      ...callDataEncodedDomain,
-      new BN(targetAddress?.slice(2), 16).toString(10),
-    ],
+    calldata: [...callDataEncodedDomain, hexToDecimal(targetAddress ?? "")],
   };
 
   const { execute: set_domain_to_address } = useStarknetExecute({

--- a/components/identities/actions/subdomainModal.tsx
+++ b/components/identities/actions/subdomainModal.tsx
@@ -5,6 +5,7 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { Call } from "starknet/types";
 import { useEncoded, useIsValid } from "../../../hooks/naming";
 import styles from "../../../styles/components/wallets.module.css";
+import { hexToDecimal } from "../../../utils/stringService";
 import SelectDomain from "../../domains/selectDomains";
 import Button from "../../UI/button";
 
@@ -62,7 +63,7 @@ const SubdomainModal: FunctionComponent<SubdomainModalProps> = ({
             Number(callDataEncodedDomain[0]) + 1,
             encodedSubdomain,
             ...callDataEncodedDomain.slice(1),
-            new BN((address as string)?.slice(2), 16).toString(10),
+            hexToDecimal(address ?? ""),
           ],
         },
       ]);
@@ -91,7 +92,7 @@ const SubdomainModal: FunctionComponent<SubdomainModalProps> = ({
             Number(callDataEncodedDomain[0]) + 1,
             encodedSubdomain,
             ...callDataEncodedDomain.slice(1),
-            new BN((address as string)?.slice(2), 16).toString(10),
+            hexToDecimal(address ?? ""),
           ],
         },
       ]);

--- a/components/identities/actions/subdomainModal.tsx
+++ b/components/identities/actions/subdomainModal.tsx
@@ -1,5 +1,5 @@
 import { Modal, TextField } from "@mui/material";
-import { useStarknetExecute } from "@starknet-react/core";
+import { useAccount, useStarknetExecute } from "@starknet-react/core";
 import { BN } from "bn.js";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { Call } from "starknet/types";
@@ -26,6 +26,7 @@ const SubdomainModal: FunctionComponent<SubdomainModalProps> = ({
   const encodedSubdomain: string = useEncoded(subdomain ?? "").toString(10);
   const isDomainValid = useIsValid(subdomain ?? "");
   const [callData, setCallData] = useState<Call[]>([]);
+  const { address } = useAccount();
 
   const { execute: transfer_domain } = useStarknetExecute({
     calls: callData as any,
@@ -54,6 +55,16 @@ const SubdomainModal: FunctionComponent<SubdomainModalProps> = ({
             targetTokenId,
           ],
         },
+        {
+          contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
+          entrypoint: "set_domain_to_address",
+          calldata: [
+            Number(callDataEncodedDomain[0]) + 1,
+            encodedSubdomain,
+            ...callDataEncodedDomain.slice(1),
+            new BN((address as string)?.slice(2), 16).toString(10),
+          ],
+        },
       ]);
     } else {
       setCallData([
@@ -73,9 +84,19 @@ const SubdomainModal: FunctionComponent<SubdomainModalProps> = ({
             newTokenId,
           ],
         },
+        {
+          contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
+          entrypoint: "set_domain_to_address",
+          calldata: [
+            Number(callDataEncodedDomain[0]) + 1,
+            encodedSubdomain,
+            ...callDataEncodedDomain.slice(1),
+            new BN((address as string)?.slice(2), 16).toString(10),
+          ],
+        },
       ]);
     }
-  }, [targetTokenId, encodedSubdomain, callDataEncodedDomain]);
+  }, [targetTokenId, encodedSubdomain, callDataEncodedDomain, address]);
 
   return (
     <Modal

--- a/components/identities/identitiesActions.tsx
+++ b/components/identities/identitiesActions.tsx
@@ -8,10 +8,9 @@ import { useEncodedSeveral } from "../../hooks/naming";
 import { BN } from "bn.js";
 import { useAccount, useStarknetExecute } from "@starknet-react/core";
 import ChangeAddressModal from "./actions/changeAddressModal";
-import { getDomainWithoutStark } from "../../utils/stringService";
+import { getDomainWithoutStark, hexToDecimal } from "../../utils/stringService";
 import TransferFormModal from "./actions/transferFormModal";
 import SubdomainModal from "./actions/subdomainModal";
-import { hexToFelt } from "../../utils/felt";
 import RenewalModal from "./actions/renewalModal";
 import SocialMediaActions from "./actions/socialmediaActions";
 import { Identity } from "../../types/backTypes";
@@ -36,7 +35,7 @@ const IdentityActions: FunctionComponent<IdentityActionsProps> = ({
   const encodedDomains = useEncodedSeveral(
     getDomainWithoutStark(identity ? identity.domain : "").split(".") ?? []
   );
-  const isAccountTargetAddress = identity?.addr === hexToFelt(address ?? "");
+  const isAccountTargetAddress = identity?.addr === hexToDecimal(address ?? "");
   const [isOwner, setIsOwner] = useState<boolean>(false);
 
   // Add all subdomains to the parameters
@@ -54,10 +53,7 @@ const IdentityActions: FunctionComponent<IdentityActionsProps> = ({
   const set_domain_to_address_calls = {
     contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
     entrypoint: "set_domain_to_address",
-    calldata: [
-      ...callDataEncodedDomain,
-      new BN((address ?? "").slice(2), 16).toString(10),
-    ],
+    calldata: [...callDataEncodedDomain, hexToDecimal(address ?? "")],
   };
   const { execute: set_address_to_domain } = useStarknetExecute({
     calls: isAccountTargetAddress
@@ -85,7 +81,7 @@ const IdentityActions: FunctionComponent<IdentityActionsProps> = ({
 
     if (address && tokenId) {
       // Our Indexer
-      fetch(`/api/indexer/addr_to_full_ids?addr=${hexToFelt(address)}`)
+      fetch(`/api/indexer/addr_to_full_ids?addr=${hexToDecimal(address)}`)
         .then((response) => response.json())
         .then((data) => {
           setIsOwner(checkIfOwner(data.full_ids));

--- a/components/identities/identityWarnings.tsx
+++ b/components/identities/identityWarnings.tsx
@@ -1,0 +1,38 @@
+import React, { FunctionComponent } from "react";
+import { Identity } from "../../types/backTypes";
+import { getDomainWithoutStark, isSubdomain } from "../../utils/stringService";
+import Link from "next/link";
+
+type IdentityWarningsProps = {
+  identity?: Identity;
+};
+
+const IdentityWarnings: FunctionComponent<IdentityWarningsProps> = ({
+  identity,
+}) => {
+  const currentTimeStamp = new Date().getTime() / 1000;
+
+  return (
+    <>
+      {Number(identity?.domain_expiry) < currentTimeStamp &&
+      !isSubdomain(identity?.domain ?? "") ? (
+        <strong className="mt-2 text-red-600 text-center">
+          (This domain has expired you can buy it on the&nbsp;
+          <span className="underline">
+            <Link
+              href={
+                "/search?domain=" +
+                getDomainWithoutStark(identity?.domain ?? "")
+              }
+            >
+              domain page
+            </Link>
+          </span>
+          )
+        </strong>
+      ) : null}
+    </>
+  );
+};
+
+export default IdentityWarnings;

--- a/hooks/naming.ts
+++ b/hooks/naming.ts
@@ -165,11 +165,6 @@ export function useUpdatedDomainFromAddress(
         setDomain(data.domain);
       });
 
-  useEffect(() => {
-    const timer = setInterval(() => updateDomain(decimalAddr), 30e3);
-    return () => clearInterval(timer);
-  }, [decimalAddr]);
-
   return domain;
 }
 

--- a/hooks/naming.ts
+++ b/hooks/naming.ts
@@ -3,6 +3,7 @@ import { BigNumberish } from "starknet/utils/number";
 import { useStarknetCall } from "@starknet-react/core";
 import { useNamingContract } from "./contracts";
 import { useState, useEffect } from "react";
+import { hexToDecimal } from "../utils/stringService";
 
 export const basicAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789-";
 export const bigAlphabet = "这来";
@@ -154,7 +155,7 @@ export function useUpdatedDomainFromAddress(
 
   useEffect(() => {
     if (!address) return;
-    setDecimalAddr(new BN((address ?? "").slice(2), 16).toString(10));
+    setDecimalAddr(hexToDecimal(address ?? ""));
     updateDomain(decimalAddr);
   }, [decimalAddr, address]);
 

--- a/pages/identities/[tokenId].tsx
+++ b/pages/identities/[tokenId].tsx
@@ -6,9 +6,8 @@ import Button from "../../components/UI/button";
 import { NextPage } from "next";
 import { ThreeDots } from "react-loader-spinner";
 import IdentityActions from "../../components/identities/identitiesActions";
-import Link from "next/link";
-import { getDomainWithoutStark, isSubdomain } from "../../utils/stringService";
 import { Identity } from "../../types/backTypes";
+import IdentityWarnings from "../../components/identities/identityWarnings";
 
 const TokenIdPage: NextPage = () => {
   const router = useRouter();
@@ -17,7 +16,6 @@ const TokenIdPage: NextPage = () => {
   const [isIdentityADomain, setIsIdentityADomain] = useState<
     boolean | undefined
   >();
-  const currentTimeStamp = new Date().getTime() / 1000;
 
   useEffect(() => {
     if (tokenId) {
@@ -79,23 +77,8 @@ const TokenIdPage: NextPage = () => {
               tokenId={tokenId}
               isIdentityADomain={isIdentityADomain}
             />
-            {Number(identity?.domain_expiry) < currentTimeStamp &&
-            !isSubdomain(identity?.domain ?? "") ? (
-              <strong className="mt-2 text-red-600 text-center">
-                (This domain has expired you can buy it on the&nbsp;
-                <span className="underline">
-                  <Link
-                    href={
-                      "/search?domain=" +
-                      getDomainWithoutStark(identity?.domain ?? "")
-                    }
-                  >
-                    domain page
-                  </Link>
-                </span>
-                )
-              </strong>
-            ) : null}
+
+            <IdentityWarnings identity={identity} />
             <div className="mt-5">
               <Button onClick={() => router.push("/")}>
                 Back to your identities

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,7 @@ import { useRouter } from "next/router";
 import LoadingScreen from "../components/UI/screens/loadingScreen";
 import ErrorScreen from "../components/UI/screens/errorScreen";
 import SuccessScreen from "../components/UI/screens/successScreen";
-import { hexToFelt } from "../utils/felt";
+import { hexToDecimal } from "../utils/stringService";
 
 const Home: NextPage = () => {
   const { address } = useAccount();
@@ -46,7 +46,7 @@ const Home: NextPage = () => {
   useEffect(() => {
     if (address) {
       // Our Indexer
-      fetch(`/api/indexer/addr_to_full_ids?addr=${hexToFelt(address)}`)
+      fetch(`/api/indexer/addr_to_full_ids?addr=${hexToDecimal(address)}`)
         .then((response) => response.json())
         .then((data) => {
           setOwnedIdentities(data.full_ids);

--- a/pages/partners.tsx
+++ b/pages/partners.tsx
@@ -9,9 +9,9 @@ import { useEffect, useState } from "react";
 import Button from "../components/UI/button";
 import ErrorScreen from "../components/UI/screens/errorScreen";
 import styles from "../styles/whitelist.module.css";
-import { hexToFelt } from "../utils/felt";
 import { useDecodedSeveral } from "../hooks/naming";
 import BN from "bn.js";
+import { hexToDecimal } from "../utils/stringService";
 
 type WhitelistedDomain = {
   domain: string;
@@ -39,7 +39,7 @@ const Whitelist: NextPage = () => {
 
   useEffect(() => {
     if (account) {
-      fetch(`/api/whitelist/${hexToFelt(account.address)}`)
+      fetch(`/api/whitelist/${hexToDecimal(account.address)}`)
         .then((response) => response.json())
         .then((data) => {
           if (data.error) {
@@ -78,7 +78,7 @@ const Whitelist: NextPage = () => {
               whitelistedDomain.domain,
               new BN(whitelistedDomain.expiry).toString(10),
               new BN(newTokenId).toString(10),
-              new BN((account?.address as string).slice(2), 16).toString(10),
+              hexToDecimal(account?.address ?? ""),
               new BN(whitelistedDomain.signature[0]).toString(10),
               new BN(whitelistedDomain.signature[1]).toString(10),
             ],

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -8,7 +8,7 @@ import SearchBar from "../components/UI/searchBar";
 import DomainCard from "../components/domains/domainCard";
 import DomainMenu from "../components/domains/domainMenu";
 import { useExpiryFromDomain } from "../hooks/naming";
-import { is1234Domain, isStarkDomain } from "../utils/stringService";
+import { is1234Domain, isStarkRootDomain } from "../utils/stringService";
 import { useAccount } from "@starknet-react/core";
 
 const SearchPage: NextPage = () => {
@@ -24,7 +24,7 @@ const SearchPage: NextPage = () => {
   useEffect(() => {
     if (
       router?.query?.domain &&
-      isStarkDomain(router.query.domain.concat(".stark") as string)
+      isStarkRootDomain(router.query.domain.concat(".stark") as string)
     ) {
       setDomain(router.query.domain as string);
     }

--- a/tests/utils/stringService.test.js
+++ b/tests/utils/stringService.test.js
@@ -9,6 +9,7 @@ import {
   minifyAddress,
   minifyDomain,
   generateString,
+  hexToDecimal,
 } from "../../utils/stringService";
 
 describe("Should test is1234Domain", () => {
@@ -78,6 +79,7 @@ describe("Should test isStarkDomain", () => {
 describe("Should test isHexString", () => {
   it("Should return false cause string is not an hex", () => {
     expect(isHexString("1232575.stark")).toBe(false);
+    expect(isHexString("1232575")).toBe(false);
   });
 
   it("Should return true cause string is hex", () => {
@@ -98,5 +100,23 @@ describe("Should test isSubdomain", () => {
   it("Should return false cause string is a subdomain", () => {
     expect(isSubdomain("1232575.ben.stark")).toBe(true);
     expect(isSubdomain("qsdqsdqsd.fricoben.stark")).toBe(true);
+  });
+});
+
+describe("Should test hexToDecimal function", () => {
+  it("Should return the right decimal address", () => {
+    expect(
+      hexToDecimal(
+        "0x072D4F3FA4661228ed0c9872007fc7e12a581E000FAd7b8f3e3e5bF9E6133207"
+      )
+    ).toEqual(
+      "3246245011749133880110396867610358293809804380010255939993086782333605065223"
+    );
+  });
+
+  it("Should return an error cause the string is not an hex number", () => {
+    expect(() => hexToDecimal("123321.ben.stark")).toThrow(
+      new Error("Invalid hex string")
+    );
   });
 });

--- a/tests/utils/stringService.test.js
+++ b/tests/utils/stringService.test.js
@@ -132,6 +132,16 @@ describe("Should test isHexString", () => {
   it("Should return false cause string is not an hex", () => {
     expect(isHexString("1232575.stark")).toBeFalsy();
     expect(isHexString("1232575")).toBeFalsy();
+    expect(
+      isHexString(
+        "061b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3"
+      )
+    ).toBeFalsy();
+    expect(
+      isHexString(
+        "0061b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3"
+      )
+    ).toBeFalsy();
   });
 
   it("Should return true cause string is hex", () => {
@@ -139,7 +149,7 @@ describe("Should test isHexString", () => {
       isHexString(
         "0x061b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3"
       )
-    ).toBeTrut;
+    ).toBeTruthy();
   });
 });
 

--- a/tests/utils/stringService.test.js
+++ b/tests/utils/stringService.test.js
@@ -3,28 +3,29 @@ import { basicAlphabet } from "../../hooks/naming";
 import {
   is1234Domain,
   getDomainWithoutStark,
-  isStarkDomain,
+  isStarkRootDomain,
   isHexString,
   isSubdomain,
   minifyAddress,
   minifyDomain,
   generateString,
   hexToDecimal,
+  isStarkDomain,
 } from "../../utils/stringService";
 
 describe("Should test is1234Domain", () => {
   it("Should return false cause there are valid 1234 domains", () => {
-    expect(is1234Domain("1231")).toBe(true);
-    expect(is1234Domain("0231")).toBe(true);
-    expect(is1234Domain("1204")).toBe(true);
-    expect(is1234Domain("0430")).toBe(true);
+    expect(is1234Domain("1231")).toBeTrut;
+    expect(is1234Domain("0231")).toBeTrut;
+    expect(is1234Domain("1204")).toBeTrut;
+    expect(is1234Domain("0430")).toBeTrut;
   });
 
   it("Should return false cause there are invalid 1234 domains", () => {
-    expect(is1234Domain("1232575")).toBe(false);
-    expect(is1234Domain("231")).toBe(false);
-    expect(is1234Domain("12043")).toBe(false);
-    expect(is1234Domain("1234")).toBe(false);
+    expect(is1234Domain("1232575")).toBeFalsy();
+    expect(is1234Domain("231")).toBeFalsy();
+    expect(is1234Domain("12043")).toBeFalsy();
+    expect(is1234Domain("1234")).toBeFalsy();
   });
 });
 
@@ -56,30 +57,81 @@ describe("Should test getDomainWithoutStark", () => {
   });
 });
 
-describe("Should test isStarkDomain", () => {
+describe("Should test isStarkRootDomain", () => {
   it("Should return true cause string is a stark domain", () => {
     for (let index = 0; index < 2500; index++) {
       const randomString = generateString(10, basicAlphabet);
-      expect(isStarkDomain(randomString + ".stark")).toBe(true);
+      expect(isStarkRootDomain(randomString + ".stark")).toBeTruthy();
     }
   });
 
   it("Should return false cause string does not end with .stark", () => {
-    expect(isStarkDomain("test.star")).toBe(false);
+    expect(isStarkRootDomain("test.star")).toBeFalsy();
   });
 
   it("Should return false cause string contains a wrong character", () => {
-    expect(isStarkDomain("test)ben.stark")).toBe(false);
-    expect(isStarkDomain("test,ben.stark")).toBe(false);
-    expect(isStarkDomain("qsd12$)ben.stark")).toBe(false);
-    expect(isStarkDomain("_.stark")).toBe(false);
+    expect(isStarkRootDomain("test)ben.stark")).toBeFalsy();
+    expect(isStarkRootDomain("test,ben.stark")).toBeFalsy();
+    expect(isStarkRootDomain("qsd12$)ben.stark")).toBeFalsy();
+    expect(isStarkRootDomain("_.stark")).toBeFalsy();
+    expect(isStarkRootDomain("test.ben.stark")).toBeFalsy();
+    expect(isStarkRootDomain("..stark")).toBeFalsy();
+    expect(isStarkRootDomain("..starkq")).toBeFalsy();
+  });
+});
+
+describe("Should test isStarkDomain", () => {
+  it("Should return true cause string is a stark subdomain", () => {
+    for (let index = 0; index < 2500; index++) {
+      const randomString = generateString(10, basicAlphabet);
+      const randomString2 = generateString(10, basicAlphabet);
+      const randomString3 = generateString(10, basicAlphabet);
+      const randomString4 = generateString(10, basicAlphabet);
+
+      expect(
+        isStarkDomain(
+          randomString +
+            "." +
+            randomString2 +
+            "." +
+            randomString3 +
+            "." +
+            randomString4 +
+            ".stark"
+        )
+      ).toBeTruthy();
+    }
+  });
+
+  it("Should return true cause string is a stark subdomain", () => {
+    for (let index = 0; index < 500; index++) {
+      const randomString = generateString(10, basicAlphabet);
+
+      expect(isStarkDomain(randomString + ".stark")).toBeTruthy();
+    }
+  });
+
+  it("Should return false cause these are not stark domains", () => {
+    const randomString = generateString(10, basicAlphabet);
+    const randomString2 = generateString(10, basicAlphabet);
+
+    expect(
+      isStarkDomain(randomString + "." + randomString2 + ".starkqsd") &&
+        isStarkDomain(
+          randomString.concat("_") + "." + randomString2 + ".stark"
+        ) &&
+        isStarkDomain(randomString + "." + randomString2 + "..stark") &&
+        isStarkDomain(randomString + "." + randomString2 + "..stark") &&
+        isStarkDomain("." + randomString + ".." + randomString2 + ".stark") &&
+        isStarkDomain("." + randomString + "." + randomString2 + ".stark")
+    ).toBeFalsy();
   });
 });
 
 describe("Should test isHexString", () => {
   it("Should return false cause string is not an hex", () => {
-    expect(isHexString("1232575.stark")).toBe(false);
-    expect(isHexString("1232575")).toBe(false);
+    expect(isHexString("1232575.stark")).toBeFalsy();
+    expect(isHexString("1232575")).toBeFalsy();
   });
 
   it("Should return true cause string is hex", () => {
@@ -87,19 +139,19 @@ describe("Should test isHexString", () => {
       isHexString(
         "0x061b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3"
       )
-    ).toBe(true);
+    ).toBeTrut;
   });
 });
 
 describe("Should test isSubdomain", () => {
   it("Should return false cause string is not a subdomain", () => {
-    expect(isSubdomain("1232575.stark")).toBe(false);
-    expect(isSubdomain("")).toBe(false);
+    expect(isSubdomain("1232575.stark")).toBeFalsy();
+    expect(isSubdomain("")).toBeFalsy();
   });
 
   it("Should return false cause string is a subdomain", () => {
-    expect(isSubdomain("1232575.ben.stark")).toBe(true);
-    expect(isSubdomain("qsdqsdqsd.fricoben.stark")).toBe(true);
+    expect(isSubdomain("1232575.ben.stark")).toBeTrut;
+    expect(isSubdomain("qsdqsdqsd.fricoben.stark")).toBeTrut;
   });
 });
 

--- a/utils/felt.js
+++ b/utils/felt.js
@@ -6,6 +6,7 @@ const P = new BN(
 );
 
 export function feltToString(felt) {
+  // eslint-disable-next-line no-undef
   const newStrB = Buffer.from(felt.toString(16), "hex");
   return newStrB.toString();
 }
@@ -14,6 +15,8 @@ export function stringToHex(str) {
   if (!str) {
     return;
   }
+
+  // eslint-disable-next-line no-undef
   return "0x" + new Buffer.from(str).toString("hex");
 }
 

--- a/utils/stringService.ts
+++ b/utils/stringService.ts
@@ -63,6 +63,12 @@ export function isSubdomain(domain: string): boolean {
 }
 
 // eslint-disable-next-line @typescript-eslint/adjacent-overload-signatures
-export function isStarkDomain(domain: string): boolean {
+export function isStarkRootDomain(domain: string): boolean {
   return /^([a-z0-9-]){1,48}\.stark$/.test(domain);
+}
+
+export function isStarkDomain(domain: string) {
+  return /^(?:[a-z0-9-]{1,48}(?:[a-z0-9-]{1,48}[a-z0-9-])?\.)*[a-z0-9-]{1,48}\.stark$/.test(
+    domain
+  );
 }

--- a/utils/stringService.ts
+++ b/utils/stringService.ts
@@ -41,11 +41,7 @@ export function getDomainWithoutStark(str: string): string {
 
 export function isHexString(str: string): boolean {
   if (str === "") return true;
-  if (str.toLowerCase().startsWith("0x")) {
-    return /^[0123456789abcdefABCDEF]+$/.test(str.slice(2));
-  } else {
-    return false;
-  }
+  return /^0x[0123456789abcdefABCDEF]+$/.test(str);
 }
 
 export function generateString(length: number, characters: string): string {

--- a/utils/stringService.ts
+++ b/utils/stringService.ts
@@ -1,8 +1,18 @@
+import BN from "bn.js";
+
 export function minifyAddress(address: string): string {
   const firstPart = address.substring(0, 4);
   const secondPart = address.substring(address.length - 3, address.length);
 
   return (firstPart + "..." + secondPart).toLowerCase();
+}
+
+export function hexToDecimal(hex: string): string {
+  if (!isHexString(hex)) {
+    throw new Error("Invalid hex string");
+  }
+
+  return new BN(hex.slice(2), 16).toString(10);
 }
 
 export function minifyDomain(
@@ -31,7 +41,11 @@ export function getDomainWithoutStark(str: string): string {
 
 export function isHexString(str: string): boolean {
   if (str === "") return true;
-  return /^[0123456789abcdefABCDEF]+$/.test(str.slice(2));
+  if (str.toLowerCase().startsWith("0x")) {
+    return /^[0123456789abcdefABCDEF]+$/.test(str.slice(2));
+  } else {
+    return false;
+  }
 }
 
 export function generateString(length: number, characters: string): string {


### PR DESCRIPTION
Cette PR rajoute : 

1) Un mutlicall pour set as main domain si le mec n'a rien de set (si l'indexer bug ça risque de set as main domain sans que le mec veuille mais c'est pas très grave en vrai). 
2) Un multicall pour set l'adresse lorsque l'on transfère un subdomain 
3) j'envoie vers le profil starknet.id/name.stark dans les details

et quelques refactors sur le code que je vois par ci par là

close #112 