### PR TITLE
fix: error 500 instead of json with error code

### DIFF
--- a/pages/api/indexer/id_to_data.ts
+++ b/pages/api/indexer/id_to_data.ts
@@ -45,7 +45,8 @@ export default async function handler(
     .collection("starknet_ids")
     .findOne({ token_id: id, "_chain.valid_to": null })
     .then((doc: any) => {
-      owner = doc.owner;
+      if (doc)
+        owner = doc.owner;
     });
 
   if (!domain || !owner) {


### PR DESCRIPTION
Fix: 

OK: https://app.starknet.id/api/indexer/id_to_data?id=659438723393
Not OK: https://app.starknet.id/api/indexer/id_to_data?id=659438723392

Should return json 200, with error text instead of 500
