### PR TITLE
Feat: add braavos, everai and og club data in indexer stats api

### DIFF
--- a/pages/api/indexer/stats/count_club_domains.ts
+++ b/pages/api/indexer/stats/count_club_domains.ts
@@ -175,8 +175,6 @@ export default async function handler(
     ])
     .toArray();
 
-  console.log("dbOutput", dbOutput);
-
   let _99;
   let _999;
   let _10k;


### PR DESCRIPTION
Update `count_club_domains` api request to return Braavos, Everai and OG subdomains data