### PR TITLE
feat: add addrs_to_domains endpoint

### DIFF
--- a/pages/api/indexer/addrs_to_domains.ts
+++ b/pages/api/indexer/addrs_to_domains.ts
@@ -1,0 +1,68 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { connectToDatabase } from "../../../lib/mongodb";
+import NextCors from "nextjs-cors";
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<Array<{ domain: string | null; address: string }>>
+) {
+    await NextCors(req, res, {
+        methods: ["POST"],
+        origin: "*",
+        optionsSuccessStatus: 200,
+    });
+
+    const { body: { addresses } } = req;
+    const { db } = await connectToDatabase();
+    const aggregationResult = await db
+        .collection("starknet_ids")
+        .aggregate([
+            {
+                $match: {
+                    owner: { $in: addresses },
+                    "_chain.valid_to": null,
+                },
+            },
+            {
+                $lookup: {
+                    from: "domains",
+                    localField: "token_id",
+                    foreignField: "token_id",
+                    as: "domain_info",
+                },
+            },
+            {
+                $unwind: {
+                    path: "$domain_info",
+                    preserveNullAndEmptyArrays: true,
+                },
+            },
+            {
+                $match: {
+                    "domain_info._chain.valid_to": { $eq: null },
+                },
+            },
+            {
+                $project: {
+                    _id: 0,
+                    domain: "$domain_info.domain",
+                    address: "$owner",
+                },
+            },
+        ])
+        .toArray();
+
+    const result = addresses.map((address: string) => {
+        const found = aggregationResult.find((item) => item.address === address);
+        if (found) {
+            return found;
+        } else {
+            return { domain: null, address };
+        }
+    });
+
+    res
+        .setHeader("cache-control", "max-age=30")
+        .status(200)
+        .json(result);
+}


### PR DESCRIPTION
This introduce a new endpoint allowing to translate multiple addresses to domain. If an address doesn't have a main domain, it will return null so it can be handled correctly on the front.

Example input:
```json
{
  "addresses" : [
"2062164617078856708726359385275913687867681308215048325959467098459703644820",
"0x00a00373A00352aa367058555149b573322910D54FCDf3a926E3E56D0dCb4b0c"
  ]
}
```

Example output:
```json
[
  {
    "domain": "th0rgal.stark",
    "address": "2062164617078856708726359385275913687867681308215048325959467098459703644820"
  },
  {
    "domain": null,
    "address": "0x00a00373A00352aa367058555149b573322910D54FCDf3a926E3E56D0dCb4b0c"
  }
]
```

Tested in local on endpoint: ``http://localhost:3000/api/indexer/addrs_to_domains``