### PR TITLE
Fix/success screen

### DIFF
--- a/components/UI/wallets.tsx
+++ b/components/UI/wallets.tsx
@@ -59,7 +59,7 @@ const Wallets: FunctionComponent<WalletsProps> = ({
             return (
               <div className="mt-5 flex justify-center" key={connector.id()}>
                 <Button onClick={() => connectWallet(connector)}>
-                  <div className="flex">
+                  <div className="flex justify-center items-center">
                     <WalletIcons id={connector.id()} />
                     {`Connect ${connector.name()}`}
                   </div>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@argent/starknet-react-webwallet-connector": "^6.0.3",
+    "@argent/starknet-react-webwallet-connector": "^6.1.2",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
     "@mui/icons-material": "^5.8.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@argent/starknet-react-webwallet-connector": "^6.0.3",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
     "@mui/icons-material": "^5.8.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,18 +5,20 @@ import Navbar from "../components/UI/navbar";
 import Head from "next/head";
 import { ThemeProvider } from "@mui/material";
 import theme from "../styles/theme";
-import { InjectedConnector, StarknetProvider } from "@starknet-react/core";
+import { InjectedConnector, StarknetConfig } from "@starknet-react/core";
+import { WebWalletConnector } from "@argent/starknet-react-webwallet-connector";
 import { Analytics } from "@vercel/analytics/react";
 
 function MyApp({ Component, pageProps }: AppProps) {
   const connectors = [
     new InjectedConnector({ options: { id: "argentX" } }),
     new InjectedConnector({ options: { id: "braavos" } }),
+    new WebWalletConnector({ url: "https://web.hydrogen.argent47.net" }),
   ];
 
   return (
     <>
-      <StarknetProvider connectors={connectors}>
+      <StarknetConfig autoConnect connectors={connectors}>
         <ThemeProvider theme={theme}>
           <Head>
             <title>Starknet.id</title>
@@ -29,7 +31,7 @@ function MyApp({ Component, pageProps }: AppProps) {
           <Component {...pageProps} />
         </ThemeProvider>
         <Analytics />
-      </StarknetProvider>
+      </StarknetConfig>
     </>
   );
 }

--- a/pages/identities.tsx
+++ b/pages/identities.tsx
@@ -94,15 +94,15 @@ const Identities: NextPage = () => {
                 data?.status !== "PENDING" && <LoadingScreen />}
               {transactionError && (
                 <ErrorScreen
-                  onClick={() => router.push("/identities")}
+                  onClick={() => router.reload()}
                   buttonText="Retry to mint"
                 />
               )}
               {data?.status === "ACCEPTED_ON_L2" ||
                 (data?.status === "PENDING" && (
                   <SuccessScreen
-                    onClick={() => router.push(`/identities`)}
-                    buttonText="See your new identity"
+                    onClick={() => router.push(`/`)}
+                    buttonText="Get a domain to your identity"
                     successMessage="Congrats, your starknet identity is minted !"
                   />
                 ))}


### PR DESCRIPTION
When someone minted and had the success screen it didn't work because the page `identities` is the same page they were on. So `router.push("/identities")` was doing nothin on the screen 