### PR TITLE
fix: success screen

### DIFF
--- a/pages/identities.tsx
+++ b/pages/identities.tsx
@@ -94,15 +94,15 @@ const Identities: NextPage = () => {
                 data?.status !== "PENDING" && <LoadingScreen />}
               {transactionError && (
                 <ErrorScreen
-                  onClick={() => router.push("/identities")}
+                  onClick={() => router.reload()}
                   buttonText="Retry to mint"
                 />
               )}
               {data?.status === "ACCEPTED_ON_L2" ||
                 (data?.status === "PENDING" && (
                   <SuccessScreen
-                    onClick={() => router.push(`/identities`)}
-                    buttonText="See your new identity"
+                    onClick={() => router.push(`/`)}
+                    buttonText="Get a domain to your identity"
                     successMessage="Congrats, your starknet identity is minted !"
                   />
                 ))}


### PR DESCRIPTION
When someone minted and had the success screen it didn't work because the page `identities` is the same page they were on. So `router.push("/identities")` was doing nothin on the screen 