### PR TITLE
feat: add query to get external domains

### DIFF
--- a/pages/api/indexer/addr_to_external_domains.ts
+++ b/pages/api/indexer/addr_to_external_domains.ts
@@ -17,7 +17,9 @@ export default async function handler(
   const addr = req.query.addr as string;
   const domainsList: string[] = [];
   const { db } = await connectToDatabase();
-  const documents = db.collection("subdomains").find({ addr: addr, "_chain.valid_to": null });
+  const documents = db
+    .collection("subdomains")
+    .find({ addr: addr, "_chain.valid_to": null });
   for (const doc of await documents.toArray()) {
     domainsList.push(doc.domain);
   }

--- a/pages/api/indexer/addr_to_external_domains.ts
+++ b/pages/api/indexer/addr_to_external_domains.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { connectToDatabase } from "../../../lib/mongodb";
+import NextCors from "nextjs-cors";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{
+    domains: string[];
+  }>
+) {
+  await NextCors(req, res, {
+    methods: ["GET"],
+    origin: "*",
+    optionsSuccessStatus: 200,
+  });
+
+  const addr = req.query.addr as string;
+  const domainsList: string[] = [];
+  const { db } = await connectToDatabase();
+  const documents = db.collection("subdomains").find({ addr: addr, "_chain.valid_to": null });
+  for (const doc of await documents.toArray()) {
+    domainsList.push(doc.domain);
+  }
+
+  res
+    .setHeader("cache-control", "max-age=30")
+    .status(200)
+    .json({ domains: domainsList });
+}

--- a/pages/api/indexer/addrs_to_domains.ts
+++ b/pages/api/indexer/addrs_to_domains.ts
@@ -3,48 +3,47 @@ import { connectToDatabase } from "../../../lib/mongodb";
 import NextCors from "nextjs-cors";
 
 export default async function handler(
-    req: NextApiRequest,
-    res: NextApiResponse<Array<{ domain: string | null; address: string }>>
+  req: NextApiRequest,
+  res: NextApiResponse<Array<{ domain: string | null; address: string }>>
 ) {
-    await NextCors(req, res, {
-        methods: ["POST"],
-        origin: "*",
-        optionsSuccessStatus: 200,
-    });
+  await NextCors(req, res, {
+    methods: ["POST"],
+    origin: "*",
+    optionsSuccessStatus: 200,
+  });
 
-    const { body: { addresses } } = req;
-    const { db } = await connectToDatabase();
-    const aggregationResult = await db
-        .collection("domains")
-        .aggregate([
-            {
-                $match: {
-                    addr: { $in: addresses },
-                    "_chain.valid_to": null,
-                    $expr: { $eq: ["$addr", "$rev_addr"] },
-                },
-            },
-            {
-                $project: {
-                    _id: 0,
-                    domain: 1,
-                    address: "$addr",
-                },
-            },
-        ])
-        .toArray();
+  const {
+    body: { addresses },
+  } = req;
+  const { db } = await connectToDatabase();
+  const aggregationResult = await db
+    .collection("domains")
+    .aggregate([
+      {
+        $match: {
+          addr: { $in: addresses },
+          "_chain.valid_to": null,
+          $expr: { $eq: ["$addr", "$rev_addr"] },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          domain: 1,
+          address: "$addr",
+        },
+      },
+    ])
+    .toArray();
 
-    const result = addresses.map((address: string) => {
-        const found = aggregationResult.find((item) => item.address === address);
-        if (found) {
-            return found;
-        } else {
-            return { domain: null, address };
-        }
-    });
+  const result = addresses.map((address: string) => {
+    const found = aggregationResult.find((item) => item.address === address);
+    if (found) {
+      return found;
+    } else {
+      return { domain: null, address };
+    }
+  });
 
-    res
-        .setHeader("cache-control", "max-age=30")
-        .status(200)
-        .json(result);
+  res.setHeader("cache-control", "max-age=30").status(200).json(result);
 }

--- a/pages/api/indexer/stats/count_created.ts
+++ b/pages/api/indexer/stats/count_created.ts
@@ -100,5 +100,4 @@ export default async function handler(
       .status(200)
       .json({ error: "delta must be greater than 3600 seconds" });
   }
-
 }

--- a/pages/api/indexer/stats/count_renewed.ts
+++ b/pages/api/indexer/stats/count_renewed.ts
@@ -22,7 +22,6 @@ export default async function handler(
   );
 
   if (deltaTime > 3600 * 1000) {
-
     const { db } = await connectToDatabase();
     const domainCollection = db.collection("domains_renewals");
 
@@ -48,10 +47,7 @@ export default async function handler(
                         {
                           $subtract: [
                             {
-                              $subtract: [
-                                "$renewal_date",
-                                new Date(beginTime),
-                              ],
+                              $subtract: ["$renewal_date", new Date(beginTime)],
                             },
                             {
                               $mod: [
@@ -101,5 +97,4 @@ export default async function handler(
       .status(200)
       .json({ error: "delta must be greater than 3600 seconds" });
   }
-
 }


### PR DESCRIPTION
This introduces a new endpoint allowing to get external subdomains (managed by a custom resolver) indexed by @irisdv .

Usage:
```
GET  addr_to_external_domains?addr=1289525220190541170709625248813865784076320381821154312029125007030504761953
```

output:
```json
{"domains":["th0r.braavos.stark"]}
```

close #222 

