### PR TITLE
fix: identities not reloaded when loading from different page

### DIFF
--- a/pages/identities.tsx
+++ b/pages/identities.tsx
@@ -64,7 +64,7 @@ const Identities: NextPage = () => {
     //   .then((data) => {
     //     setOwnedIdentities(data.assets);
     //   });
-  }, [account]);
+  }, [account, router.asPath]);
 
   return (
     <div className={styles.screen}>


### PR DESCRIPTION
This should hopefully close #223 

I added the router path (basically the page url) to the useEffects to force the identities fetch when the page is rerendered. I couldn't reproduce the bug after this fix, but it is not easy to reproduce, so it might not be fully fixed.