### PR TITLE
fix: secrets must not be accessible outside /api/

### DIFF
--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Db, MongoClient } from "mongodb";
 
-const uri = process.env.NEXT_PUBLIC_MONGODB_LINK;
+const uri = process.env.MONGODB_LINK;
 
 let client: MongoClient | undefined = undefined;
 let db: Db | undefined = undefined;
@@ -23,6 +23,6 @@ export async function connectToDatabase() {
   } else {
     client = await new MongoClient(uri as string).connect();
   }
-  db = (client as MongoClient).db(process.env.NEXT_PUBLIC_MONGODB_DBNAME);
+  db = (client as MongoClient).db(process.env.MONGODB_DBNAME);
   return { client, db };
 }

--- a/pages/api/twitter/get_username.ts
+++ b/pages/api/twitter/get_username.ts
@@ -8,7 +8,7 @@ export default async function handler(
   const {
     query: { id },
   } = req;
-  const client = new Client(process.env.NEXT_PUBLIC_TWITTER_TOKEN as string);
+  const client = new Client(process.env.TWITTER_TOKEN as string);
   const response = await client.users.findUsersById({ ids: [id as string] });
   res
     .setHeader("cache-control", "max-age=86400")


### PR DESCRIPTION
Please Approve but don't merge, this requires some work on the vercel side. NEXT_PUBLIC_ prefix specify that an env variable is accessible everywhere in the app, we should not allow that, especially for the mongodb link or our auth tokens.