### PR TITLE
Feat/add renew sponsor

### DIFF
--- a/abi/starknet/naming_abi.json
+++ b/abi/starknet/naming_abi.json
@@ -2,6 +2,43 @@
   {
     "members": [
       {
+        "name": "owner",
+        "offset": 0,
+        "type": "felt"
+      },
+      {
+        "name": "resolver",
+        "offset": 1,
+        "type": "felt"
+      },
+      {
+        "name": "address",
+        "offset": 2,
+        "type": "felt"
+      },
+      {
+        "name": "expiry",
+        "offset": 3,
+        "type": "felt"
+      },
+      {
+        "name": "key",
+        "offset": 4,
+        "type": "felt"
+      },
+      {
+        "name": "parent_key",
+        "offset": 5,
+        "type": "felt"
+      }
+    ],
+    "name": "DomainData",
+    "size": 6,
+    "type": "struct"
+  },
+  {
+    "members": [
+      {
         "name": "low",
         "offset": 0,
         "type": "felt"
@@ -14,6 +51,33 @@
     ],
     "name": "Uint256",
     "size": 2,
+    "type": "struct"
+  },
+  {
+    "members": [
+      {
+        "name": "domain_len_range",
+        "offset": 0,
+        "type": "(felt, felt)"
+      },
+      {
+        "name": "days_range",
+        "offset": 2,
+        "type": "(felt, felt)"
+      },
+      {
+        "name": "timestamp_range",
+        "offset": 4,
+        "type": "(felt, felt)"
+      },
+      {
+        "name": "amount",
+        "offset": 6,
+        "type": "felt"
+      }
+    ],
+    "name": "Discount",
+    "size": 7,
     "type": "struct"
   },
   {
@@ -110,6 +174,29 @@
         "type": "felt*"
       },
       {
+        "name": "prev_owner",
+        "type": "felt"
+      },
+      {
+        "name": "new_owner",
+        "type": "felt"
+      }
+    ],
+    "keys": [],
+    "name": "domain_transfer",
+    "type": "event"
+  },
+  {
+    "data": [
+      {
+        "name": "domain_len",
+        "type": "felt"
+      },
+      {
+        "name": "domain",
+        "type": "felt*"
+      },
+      {
         "name": "owner",
         "type": "felt"
       },
@@ -149,10 +236,6 @@
       },
       {
         "name": "admin",
-        "type": "felt"
-      },
-      {
-        "name": "whitelisting_key",
         "type": "felt"
       },
       {
@@ -201,6 +284,27 @@
       {
         "name": "expiry",
         "type": "felt"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "domain_len",
+        "type": "felt"
+      },
+      {
+        "name": "domain",
+        "type": "felt*"
+      }
+    ],
+    "name": "domain_to_data",
+    "outputs": [
+      {
+        "name": "data",
+        "type": "DomainData"
       }
     ],
     "stateMutability": "view",
@@ -333,6 +437,10 @@
       {
         "name": "address",
         "type": "felt"
+      },
+      {
+        "name": "sponsor",
+        "type": "felt"
       }
     ],
     "name": "buy",
@@ -341,10 +449,6 @@
   },
   {
     "inputs": [
-      {
-        "name": "from_address",
-        "type": "felt"
-      },
       {
         "name": "token_id",
         "type": "felt"
@@ -364,11 +468,15 @@
       {
         "name": "address",
         "type": "felt"
+      },
+      {
+        "name": "discount_id",
+        "type": "felt"
       }
     ],
-    "name": "buy_from_eth",
+    "name": "buy_discounted",
     "outputs": [],
-    "type": "l1_handler"
+    "type": "function"
   },
   {
     "inputs": [
@@ -378,6 +486,10 @@
       },
       {
         "name": "days",
+        "type": "felt"
+      },
+      {
+        "name": "sponsor",
         "type": "felt"
       }
     ],
@@ -478,33 +590,15 @@
   {
     "inputs": [
       {
-        "name": "domain",
+        "name": "discount_id",
         "type": "felt"
       },
       {
-        "name": "expiry",
-        "type": "felt"
-      },
-      {
-        "name": "starknet_id",
-        "type": "felt"
-      },
-      {
-        "name": "receiver_address",
-        "type": "felt"
-      },
-      {
-        "name": "sig",
-        "type": "(felt, felt)"
+        "name": "discount",
+        "type": "Discount"
       }
     ],
-    "name": "whitelisted_mint",
-    "outputs": [],
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "end_whitelist",
+    "name": "write_discount",
     "outputs": [],
     "type": "function"
   },
@@ -516,6 +610,17 @@
       }
     ],
     "name": "set_l1_contract",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "address",
+        "type": "felt"
+      }
+    ],
+    "name": "set_referral_contract",
     "outputs": [],
     "type": "function"
   },

--- a/components/braavos/braavosRenewal.tsx
+++ b/components/braavos/braavosRenewal.tsx
@@ -33,7 +33,7 @@ const BraavosRenewal: FunctionComponent<BraavosRenewalProps> = ({ domain }) => {
     {
       contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
       entrypoint: "renew",
-      calldata: [utils.encodeDomain(domain).toString(), 3 * 365],
+      calldata: [utils.encodeDomain(domain).toString(), 3 * 365, 0],
     },
     {
       contractAddress: process.env

--- a/components/identities/actions/renewalModal.tsx
+++ b/components/identities/actions/renewalModal.tsx
@@ -50,7 +50,7 @@ const RenewalModal: FunctionComponent<RenewalModalProps> = ({
     {
       contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
       entrypoint: "renew",
-      calldata: [callDataEncodedDomain[1], duration * 365],
+      calldata: [callDataEncodedDomain[1], duration * 365, 0],
     },
   ];
 


### PR DESCRIPTION
This pull request updates the app to the new ``renew`` method taking a sponsor parameter. It uses the "0" sponsor for now, in the future we might want to use a cookie or something similar like we do for buying.