### PR TITLE
feat: add groups to add_metadata

### DIFF
--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -40,6 +40,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain }) => {
   const maxYearsToRegister = 25;
   const [targetAddress, setTargetAddress] = useState<string>("");
   const [email, setEmail] = useState<string>("");
+  const [groups, setGroups] = useState<Array<string>>(["98125177486837731"]);
   const [emailError, setEmailError] = useState<boolean>(false);
   const [isUsResident, setIsUsResident] = useState<boolean>(false);
   const [usState, setUsState] = useState<string>("DE");
@@ -100,7 +101,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain }) => {
     // salt must not be empty to preserve privacy
     if (!salt) return;
     (async () => {
-      setMetadataHash(await computeMetadataHash(email, usState, salt));
+      setMetadataHash(await computeMetadataHash(email, groups, usState, salt));
     })();
   }, [email, usState, salt]);
 
@@ -248,6 +249,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain }) => {
       body: JSON.stringify({
         meta_hash: metadataHash,
         email: email,
+        groups,
         tax_state: usState,
         salt: salt,
       }),

--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -248,7 +248,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain }) => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         meta_hash: metadataHash,
-        email: email,
+        email,
         groups,
         tax_state: usState,
         salt: salt,

--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -40,7 +40,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain }) => {
   const maxYearsToRegister = 25;
   const [targetAddress, setTargetAddress] = useState<string>("");
   const [email, setEmail] = useState<string>("");
-  const [groups, setGroups] = useState<Array<string>>(["98125177486837731"]);
+  const [groups, setGroups] = useState<string[]>(["98125177486837731"]);
   const [emailError, setEmailError] = useState<boolean>(false);
   const [isUsResident, setIsUsResident] = useState<boolean>(false);
   const [usState, setUsState] = useState<string>("DE");

--- a/pages/api/indexer/addr_to_available_ids.ts
+++ b/pages/api/indexer/addr_to_available_ids.ts
@@ -5,7 +5,7 @@ import NextCors from "nextjs-cors";
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<{
-    ids: Array<string>;
+    ids: string[];
   }>
 ) {
   await NextCors(req, res, {
@@ -16,7 +16,7 @@ export default async function handler(
   const {
     query: { addr },
   } = req;
-  const ids: Array<string> = [];
+  const ids: string[] = [];
   const { db } = await connectToDatabase();
   const documents = db
     .collection("starknet_ids")

--- a/pages/api/indexer/addr_to_domains.ts
+++ b/pages/api/indexer/addr_to_domains.ts
@@ -5,7 +5,7 @@ import NextCors from "nextjs-cors";
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<{
-    domains: Array<string>;
+    domains: string[];
   }>
 ) {
   await NextCors(req, res, {
@@ -16,7 +16,7 @@ export default async function handler(
   const {
     query: { addr },
   } = req;
-  const _domains: Array<string> = [];
+  const _domains: string[] = [];
   const { db } = await connectToDatabase();
   const documents = db
     .collection("starknet_ids")

--- a/pages/api/indexer/uri.ts
+++ b/pages/api/indexer/uri.ts
@@ -9,7 +9,7 @@ type TokenURI = {
   expiry?: number;
   attributes?: Array<{
     trait_type: string;
-    value: string | number | Array<string>;
+    value: string | number | string[];
   }>;
 };
 

--- a/utils/userDataService.ts
+++ b/utils/userDataService.ts
@@ -10,10 +10,12 @@ export function generateSalt(): string {
 
 export async function computeMetadataHash(
   email: string,
+  groups: Array<string>,
   taxState: string,
   salt: string
 ): Promise<string> {
-  const message: string = [email, taxState, salt].join("|");
+  const groupsStr: string = groups.join(",");
+  const message: string = [email, taxState, groupsStr, salt].join("|");
   const encoder = new TextEncoder();
   const data: Uint8Array = encoder.encode(message);
   const hashBuffer: ArrayBuffer = await crypto.subtle.digest("SHA-256", data);

--- a/utils/userDataService.ts
+++ b/utils/userDataService.ts
@@ -10,7 +10,7 @@ export function generateSalt(): string {
 
 export async function computeMetadataHash(
   email: string,
-  groups: Array<string>,
+  groups: string[],
   taxState: string,
   salt: string
 ): Promise<string> {


### PR DESCRIPTION
This pull request adds email groups support to add_metadata as required by the new server. Can be merged already, the server is in prod.