### PR TITLE
Feat/improve wording

### DIFF
--- a/components/domains/externalDomainActions.tsx
+++ b/components/domains/externalDomainActions.tsx
@@ -55,7 +55,7 @@ const ExternalDomainActions: FunctionComponent<ExternalDomainActionsProps> = ({
           <div className="flex flex-col items-center justify-center">
             <ClickableAction
               title="Set as main domain"
-              description="Set this domain as your main domain"
+              description="Display this domain when connecting to dapps"
               icon={
                 <MainIcon
                   width="25"

--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -299,7 +299,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
           <div className="flex flex-col items-start gap-6 self-stretch">
             {onForceEmail ? (
               <TextField
-                helperText="We won't share your email with anyone. We'll use it only to inform you about your domain and our news."
+                helperText="Secure your domain's future and stay ahead with vital updates. Your email stays private with us, always."
                 label="Email address"
                 value={email}
                 onChange={(e) => changeEmail(e.target.value)}

--- a/components/identities/actions/clickable/clickableWarningIcon.tsx
+++ b/components/identities/actions/clickable/clickableWarningIcon.tsx
@@ -59,8 +59,8 @@ const ClickableWarningIcon: FunctionComponent<ClickableWarningIconProps> = ({
                 Update Verification Status
               </div>
               <div className={styles.tooltipSub}>
-                Your need to upgrade this verification to the new starknet
-                version, please upgrade to not loose your verification.
+                Update to the new StarkNet version to maintain your verification
+                status.
               </div>
             </div>
             <div>

--- a/components/identities/actions/identityActions.tsx
+++ b/components/identities/actions/identityActions.tsx
@@ -133,7 +133,7 @@ const IdentityActions: FunctionComponent<IdentityActionsProps> = ({
                 <ClickableAction
                   title="RENEW YOUR DOMAIN"
                   style="primary"
-                  description={`Expires on ${timestampToReadableDate(
+                  description={`Will expire on ${timestampToReadableDate(
                     identity?.domain_expiry ?? 0
                   )}`}
                   icon={
@@ -169,7 +169,7 @@ const IdentityActions: FunctionComponent<IdentityActionsProps> = ({
                 <>
                   <ClickableAction
                     title="MOVE YOUR IDENTITY NFT"
-                    description="Move your identity to another wallet"
+                    description="Transfer your identity to another wallet"
                     icon={
                       <TransferIcon
                         width="25"

--- a/components/identities/actions/renewalModal.tsx
+++ b/components/identities/actions/renewalModal.tsx
@@ -109,12 +109,12 @@ const RenewalModal: FunctionComponent<RenewalModalProps> = ({
           <div className="mt-5 flex flex-col justify-center">
             {identity?.domain_expiry && (
               <p>
-                The Expiry Data of {identity?.domain} is{" "}
+                The date of expiry of {identity?.domain} is{" "}
                 <strong>
                   {timestampToReadableDate(identity?.domain_expiry ?? 0)}
                 </strong>
-                . If you don&apos;t renew your domain before the expiry date
-                someone else will be able to take it from you.
+                . If you don&apos;t renew your domain before it expires, someone
+                else will be able to take it from you.
               </p>
             )}
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,8 +13,7 @@ const Domain: NextPage = () => {
             <div className="flex flex-col justify-start items-start text-center sm:text-start">
               <h1 className="title">Choose your Stark Domain</h1>
               <p className="description">
-                Be unmistakable on Starknet: One profile, seamlessly connecting
-                you to the entire ecosystem.
+                Your name, seamlessly connecting you to the entire ecosystem.
               </p>
             </div>
             <SearchBar showHistory />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,8 +13,8 @@ const Domain: NextPage = () => {
             <div className="flex flex-col justify-start items-start text-center sm:text-start">
               <h1 className="title">Choose your Stark Domain</h1>
               <p className="description">
-                Your unified profile across the starknet ecosystem, one name for
-                all your Starknet on-chain identity.
+                Be unmistakable on Starknet: One profile, seamlessly connecting
+                you to the entire ecosystem.
               </p>
             </div>
             <SearchBar showHistory />


### PR DESCRIPTION
I changed some wording to fix typo and improve message clarity.

### **Set as main domain:**
**Before:** 
`Set this domain as your main domain`
**After:** 
`Display this domain when connecting to dapps`
**Rationale:** 
Content was redundant with title. Main domain is something that often confuses users, let's take this opportunity to add more context about what this means to set a domain as main.

---

### **Emails catchphrase:**
**Before:** 
`We won't share your email with anyone. We'll use it only to inform you about your domain and our news.`
**After:** 
`Secure your domain's future and stay ahead with vital updates. Your email stays private with us, always.`
**Rationale:** 
It places the benefit for the user first and use positive wording for the privacy (instead of "we won't do X bad", "we will do Y good"). It also adds a glimpse of scarcity with "vital". You don't commit to a newsletter, you avoid missing an opportunity.

---

### **Domain catchphrase:**
**Before:** 
`Your unified profile across the starknet ecosystem, one name for all your Starknet on-chain identity.`
**After:** 
`Be unmistakable on Starknet: One profile, seamlessly connecting you to the entire ecosystem.`
**Rationale:** 
Tbh the first one was already nice but I prefer this wording. It also emphasizes the user's benefit: you're no longer a number, you become unmistakable.

---


The rest is typo fix
                  
