### PR TITLE
fix: identity name not displayed on id without domains

### DIFF
--- a/components/identities/identityCard.tsx
+++ b/components/identities/identityCard.tsx
@@ -27,7 +27,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
   identity,
   isOwner,
 }) => {
-  const responsiveDomainOrId = identity
+  const responsiveDomainOrId = identity?.domain
     ? shortenDomain(identity.domain as string, 25)
     : `SID: ${tokenId}`;
   const [copied, setCopied] = useState(false);


### PR DESCRIPTION
This pull request fixes the fact that id without a domain name were not displayed as "SID X" in the id card component. The reason why it happens is because the API now returns data about an id in ``id_to_data`` even though it has no domain (this is now an optional field). The fix is very simple.