### PR TITLE
fix: use cairo2 way to set main id

### DIFF
--- a/components/discount/registerDiscount.tsx
+++ b/components/discount/registerDiscount.tsx
@@ -170,7 +170,7 @@ const RegisterDiscount: FunctionComponent<RegisterDiscountProps> = ({
 
     // If the user do not have a main domain and the address match
     if (addressesMatch && !hasMainDomain) {
-      calls.push(registrationCalls.addressToDomain(encodedDomain));
+      calls.push(registrationCalls.mainId(newTokenId));
     }
 
     // If the user has toggled autorenewal

--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -197,7 +197,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
 
     // If the user do not have a main domain and the address match
     if (addressesMatch && !hasMainDomain) {
-      calls.push(registrationCalls.addressToDomain(encodedDomain));
+      calls.push(registrationCalls.mainId(newTokenId));
     }
 
     // If the user has toggled autorenewal

--- a/tests/utils/apiWrappers/identity.test.ts
+++ b/tests/utils/apiWrappers/identity.test.ts
@@ -42,6 +42,7 @@ function getSampleData1(): IdentityData {
     main: false,
     creation_date: 1671228830,
     domain: {
+      migrated: false,
       domain: "th0rgal.stark",
       root: true,
       creation_date: 1671228943,
@@ -129,6 +130,7 @@ function getSampleData2(): IdentityData {
     creation_date: 1671228830,
     domain: {
       domain: "th0rgal.stark",
+      migrated: false,
       root: true,
       creation_date: 1671228943,
       expiry: 1828908943,

--- a/types/backTypes.d.ts
+++ b/types/backTypes.d.ts
@@ -12,6 +12,7 @@ interface IdentityData {
 
 interface Domain {
   domain: string;
+  migrated : boolean;
   root: boolean;
   creation_date: number;
   expiry?: number;

--- a/utils/callData/registrationCalls.ts
+++ b/utils/callData/registrationCalls.ts
@@ -56,19 +56,19 @@ function buy_discounted(
   };
 }
 
-function addressToDomain(encodedDomain: string): Call {
-  return {
-    contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
-    entrypoint: "set_address_to_domain",
-    calldata: [1, encodedDomain],
-  };
-}
-
 function mint(tokenId: number): Call {
   return {
     contractAddress: process.env.NEXT_PUBLIC_STARKNETID_CONTRACT as string,
     entrypoint: "mint",
     calldata: [numberToString(tokenId)],
+  };
+}
+
+function mainId(tokenId: number): Call {
+  return {
+    contractAddress: process.env.NEXT_PUBLIC_STARKNETID_CONTRACT as string,
+    entrypoint: "set_main_id",
+    calldata: [tokenId],
   };
 }
 
@@ -133,7 +133,7 @@ function multiCallFreeRenewals(encodedDomains: string[]): Call[] {
 const registrationCalls = {
   approve,
   buy,
-  addressToDomain,
+  mainId,
   mint,
   buy_discounted,
   vatTransfer,


### PR DESCRIPTION
This pull request fixes the way to set your main domain when you mint a new one by using set_main_id and not the legacy set_address_to_domain which should only be used for custom resolvers.