### PR TITLE
fix: logo in nav animation

### DIFF
--- a/components/UI/navbar.tsx
+++ b/components/UI/navbar.tsx
@@ -231,7 +231,7 @@ const Navbar: FunctionComponent = () => {
               ${nav ? styles.mobileNavbarShown : styles.mobileNavbarHidden}`}
           >
             <div className="h-full flex flex-col">
-              <div className="flex w-full items-center justify-between">
+              <div className={styles.mobileNavBarHeader}>
                 <div>
                   <Link href="/" className="cursor-pointer">
                     <img

--- a/styles/components/navbar.module.css
+++ b/styles/components/navbar.module.css
@@ -65,6 +65,15 @@
   height: 12vh;
 }
 
+.mobileNavBarHeader {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  height: 80px;
+  padding-left: 4px;
+}
+
 @media (max-width: 768px) {
   .navbarContainer {
     height: 80px;


### PR DESCRIPTION
https://github.com/starknet-id/starknet.quest/pull/425#pullrequestreview-1797146471
There is a slight pixel offset when opening the menu between the logo and the close icon compared to the original ones. Can we fix that? **_It seems to me that this also happens on Starknet ID_**