### PR TITLE
fix: buy interface changed with cairo 2 update

### DIFF
--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -188,6 +188,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
 
   useEffect(() => {
     const referralData = localStorage.getItem("referralData");
+    console.log("chosing sponsor!");
     if (referralData) {
       const data = JSON.parse(referralData);
       if (data.sponsor && data?.expiry >= new Date().getTime()) {
@@ -214,7 +215,6 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
       registrationCalls.buy(
         encodedDomain,
         tokenId === 0 ? newTokenId : tokenId,
-        targetAddress,
         sponsor,
         duration,
         txMetadataHash

--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -54,7 +54,6 @@ type RegisterV2Props = {
 const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
   const router = useRouter();
   const maxYearsToRegister = 25;
-  const [targetAddress, setTargetAddress] = useState<string>("");
   const [email, setEmail] = useState<string>("");
   const [emailError, setEmailError] = useState<boolean>(true);
   const [isSwissResident, setIsSwissResident] = useState<boolean>(false);
@@ -181,14 +180,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
   }, [balance, price]);
 
   useEffect(() => {
-    if (address) {
-      setTargetAddress(address);
-    }
-  }, [address]);
-
-  useEffect(() => {
     const referralData = localStorage.getItem("referralData");
-    console.log("chosing sponsor!");
     if (referralData) {
       const data = JSON.parse(referralData);
       if (data.sponsor && data?.expiry >= new Date().getTime()) {
@@ -206,8 +198,6 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
     // Variables
     const newTokenId: number = Math.floor(Math.random() * 1000000000000);
     const txMetadataHash = "0x" + metadataHash;
-    const addressesMatch =
-      hexToDecimal(address) === hexToDecimal(targetAddress);
 
     // Common calls
     const calls = [
@@ -233,8 +223,8 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
       tokenIdToUse = newTokenId;
     }
 
-    // If the user do not have a main domain and the address match
-    if (addressesMatch && !hasMainDomain) {
+    // If the user do not have a main domain
+    if (!hasMainDomain) {
       calls.push(registrationCalls.mainId(tokenIdToUse));
     }
 
@@ -261,7 +251,6 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
   }, [
     tokenId,
     duration,
-    targetAddress,
     price,
     encodedDomain,
     hasMainDomain,
@@ -336,10 +325,6 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
     }
   }, [isSwissResident, price, needMedadata, salesTaxRate]);
 
-  function changeAddress(value: string): void {
-    isHexString(value) ? setTargetAddress(value) : null;
-  }
-
   function changeEmail(value: string): void {
     setEmail(value);
     setEmailError(isValidEmail(value) ? false : true);
@@ -389,14 +374,6 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
                 }
               />
             ) : null}
-            <TextField
-              helperText="The Starknet address the domain will resolve to."
-              label="Target address"
-              value={targetAddress ?? "0x.."}
-              onChange={(e) => changeAddress(e.target.value)}
-              color="secondary"
-              required
-            />
             <SelectIdentity tokenId={tokenId} changeTokenId={changeTokenId} />
             <NumberTextField
               value={duration}
@@ -446,7 +423,6 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
                 !account ||
                 !duration ||
                 duration < 1 ||
-                !targetAddress ||
                 invalidBalance ||
                 !termsBox ||
                 (needMedadata && emailError)

--- a/utils/callData/registrationCalls.ts
+++ b/utils/callData/registrationCalls.ts
@@ -13,7 +13,6 @@ function approve(price: string): Call {
 function buy(
   encodedDomain: string,
   tokenId: number,
-  targetAddress: string,
   sponsor: string,
   durationInYears: number,
   metadata: string
@@ -22,12 +21,19 @@ function buy(
     contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
     entrypoint: "buy",
     calldata: [
+      // id
       numberToString(tokenId),
+      // domain
       encodedDomain,
+      // days
       numberToString(durationInYears * 365),
+      // resolver
       0,
-      hexToDecimal(targetAddress),
+      // sponsor
       sponsor,
+      // discount
+      0,
+      // metadata
       metadata,
     ],
   };


### PR DESCRIPTION
This pull request fixes an issue in the Cairo 2 updated frontend. We didn't follow the correct buy interface, thus passing the targetAddress (which was removed in Cairo 2) as the sponsor param.

With the cairo 2 update we removed the targetAddress field in the buy. Instead by default a domain will resolve to his starknet id owner. If we wanted to make sure the targetAddress is something specific (not his owner), we could still do it with a multicall on the starknetid, that would be much cleaner.