### PR TITLE
fix: force rebuild with starknetid.js 3.0.3 (mainnet compat)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-icons": "^4.4.0",
     "react-loader-spinner": "5.4.5",
     "starknet": "^5.24.3",
-    "starknetid.js": "^3.0.0",
+    "starknetid.js": "^3.0.3",
     "starknetkit": "^1.1.3",
     "twitter-api-sdk": "^1.2.1"
   },


### PR DESCRIPTION
This pull request will force starknetid.js to update in vercel build so we get the main domain to be correct.