### PR TITLE
fix: use domain len instead of domain

### DIFF
--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -83,7 +83,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
     address: contract?.address as string,
     abi: contract?.abi as Abi,
     functionName: "compute_buy_price",
-    args: [encodedDomain, duration * 365],
+    args: [domain.length, duration * 365],
   });
 
   const { account, address } = useAccount();


### PR DESCRIPTION
This PR updates the call to the pricing contract that now expects the len of the domain instead of the domain itself.