### PR TITLE
fix: set as main domain

### DIFF
--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { FunctionComponent, useEffect, useState } from "react";
 import Button from "../UI/button";
 import { usePricingContract } from "../../hooks/contracts";
@@ -219,7 +219,6 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
 
     // If the user do not have a main domain
     if (!hasMainDomain) {
-      calls.push(registrationCalls.resetAddrToDomain());
       calls.push(registrationCalls.mainId(tokenIdToUse));
     }
 

--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { FunctionComponent, useEffect, useState } from "react";
 import Button from "../UI/button";
 import { usePricingContract } from "../../hooks/contracts";
@@ -219,6 +219,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
 
     // If the user do not have a main domain
     if (!hasMainDomain) {
+      calls.push(registrationCalls.resetAddrToDomain());
       calls.push(registrationCalls.mainId(tokenIdToUse));
     }
 

--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -88,7 +88,7 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
   const { writeAsync: execute, data: registerData } = useContractWrite({
     calls: callData,
   });
-  const hasMainDomain = !useDomainFromAddress(address ?? "").domain.endsWith(
+  const hasMainDomain = useDomainFromAddress(address ?? "").domain.endsWith(
     ".stark"
   );
   const [domainsMinting, setDomainsMinting] = useState<Map<string, boolean>>(

--- a/components/domains/registerV2.tsx
+++ b/components/domains/registerV2.tsx
@@ -16,7 +16,6 @@ import {
 } from "../../utils/stringService";
 import { applyRateToBigInt, gweiToEth } from "../../utils/feltService";
 import SelectIdentity from "./selectIdentity";
-import { useDisplayName } from "../../hooks/displayName.tsx";
 import { Abi, Call } from "starknet";
 import { posthog } from "posthog-js";
 import styles from "../../styles/components/registerV2.module.css";
@@ -40,6 +39,7 @@ import {
 import useAllowanceCheck from "../../hooks/useAllowanceCheck";
 import { useRouter } from "next/router";
 import ConnectButton from "../UI/connectButton";
+import { useDomainFromAddress } from "@/hooks/naming";
 
 type RegisterV2Props = {
   domain: string;
@@ -88,7 +88,9 @@ const RegisterV2: FunctionComponent<RegisterV2Props> = ({ domain, groups }) => {
   const { writeAsync: execute, data: registerData } = useContractWrite({
     calls: callData,
   });
-  const hasMainDomain = !useDisplayName(address ?? "", false).startsWith("0x");
+  const hasMainDomain = !useDomainFromAddress(address ?? "").domain.endsWith(
+    ".stark"
+  );
   const [domainsMinting, setDomainsMinting] = useState<Map<string, boolean>>(
     new Map()
   );

--- a/components/identities/actions/identityActions.tsx
+++ b/components/identities/actions/identityActions.tsx
@@ -240,20 +240,20 @@ const IdentityActions: FunctionComponent<IdentityActionsProps> = ({
                   onClick={() => router.push("/renewal")}
                 />
               ) : null}
-              {!identity.isMain && (
-                <ClickableAction
-                  title="Set as main domain"
-                  description="Set this identity as your main id"
-                  icon={
-                    <MainIcon
-                      width="23"
-                      firstColor={theme.palette.secondary.main}
-                      secondColor={theme.palette.secondary.main}
-                    />
-                  }
-                  onClick={() => setMainId()}
-                />
-              )}
+              {/* {!identity.isMain && ( */}
+              <ClickableAction
+                title="Set as main domain"
+                description="Set this identity as your main id"
+                icon={
+                  <MainIcon
+                    width="23"
+                    firstColor={theme.palette.secondary.main}
+                    secondColor={theme.palette.secondary.main}
+                  />
+                }
+                onClick={() => setMainId()}
+              />
+              {/* )} */}
               <ClickableAction
                 title="CHANGE DOMAIN TARGET"
                 description="Change target address"

--- a/components/identities/actions/identityActions.tsx
+++ b/components/identities/actions/identityActions.tsx
@@ -178,6 +178,8 @@ const IdentityActions: FunctionComponent<IdentityActionsProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [disableRenewalData]); // We want to execute this effect only once, when the transaction is sent
 
+  console.log("identity", identity);
+
   return (
     <div className={styles.actionsContainer}>
       <>
@@ -240,20 +242,20 @@ const IdentityActions: FunctionComponent<IdentityActionsProps> = ({
                   onClick={() => router.push("/renewal")}
                 />
               ) : null}
-              {/* {!identity.isMain && ( */}
-              <ClickableAction
-                title="Set as main domain"
-                description="Set this identity as your main id"
-                icon={
-                  <MainIcon
-                    width="23"
-                    firstColor={theme.palette.secondary.main}
-                    secondColor={theme.palette.secondary.main}
-                  />
-                }
-                onClick={() => setMainId()}
-              />
-              {/* )} */}
+              {!identity.isMain && (
+                <ClickableAction
+                  title="Set as main domain"
+                  description="Set this identity as your main id"
+                  icon={
+                    <MainIcon
+                      width="23"
+                      firstColor={theme.palette.secondary.main}
+                      secondColor={theme.palette.secondary.main}
+                    />
+                  }
+                  onClick={() => setMainId()}
+                />
+              )}
               <ClickableAction
                 title="CHANGE DOMAIN TARGET"
                 description="Change target address"

--- a/utils/callData/registrationCalls.ts
+++ b/utils/callData/registrationCalls.ts
@@ -78,6 +78,14 @@ function mainId(tokenId: number): Call {
   };
 }
 
+function resetAddrToDomain(): Call {
+  return {
+    contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
+    entrypoint: "reset_address_to_domain",
+    calldata: [],
+  };
+}
+
 function vatTransfer(amount: string): Call {
   return {
     contractAddress: process.env.NEXT_PUBLIC_ETHER_CONTRACT as string,
@@ -134,6 +142,7 @@ const registrationCalls = {
   approve,
   buy,
   mainId,
+  resetAddrToDomain,
   mint,
   buy_discounted,
   vatTransfer,

--- a/utils/callData/registrationCalls.ts
+++ b/utils/callData/registrationCalls.ts
@@ -78,14 +78,6 @@ function mainId(tokenId: number): Call {
   };
 }
 
-function resetAddrToDomain(): Call {
-  return {
-    contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
-    entrypoint: "reset_address_to_domain",
-    calldata: [],
-  };
-}
-
 function vatTransfer(amount: string): Call {
   return {
     contractAddress: process.env.NEXT_PUBLIC_ETHER_CONTRACT as string,
@@ -142,7 +134,6 @@ const registrationCalls = {
   approve,
   buy,
   mainId,
-  resetAddrToDomain,
   mint,
   buy_discounted,
   vatTransfer,


### PR DESCRIPTION
Close #716 

Error originated from the check of `hasMainDomain` in the register component. The error occurred for user that had a domain starting with `0x`. I updated the check, and added an additional verification in the identity page to show the set as main domain button for users that had this bug. 