### PR TITLE
fix: set_address_to_domain

### DIFF
--- a/components/domains/externalDomainActions.tsx
+++ b/components/domains/externalDomainActions.tsx
@@ -38,7 +38,10 @@ const ExternalDomainActions: FunctionComponent<ExternalDomainActionsProps> = ({
   const set_address_to_domain_calls = {
     contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
     entrypoint: "set_address_to_domain",
-    calldata: callDataEncodedDomain,
+    calldata:
+      process.env.NEXT_PUBLIC_IS_TESTNET === "true"
+        ? [...callDataEncodedDomain, 0]
+        : callDataEncodedDomain,
   };
   const { writeAsync: set_address_to_domain } = useContractWrite({
     calls: [set_address_to_domain_calls],

--- a/utils/callData/solanaCalls.ts
+++ b/utils/callData/solanaCalls.ts
@@ -27,10 +27,14 @@ function setResolving(encodedDomain: string, targetAddr: string): Call {
 
 function setAsMainDomain(encodedDomain: string): Call {
   const rootDomain = "16434"; // sol encoded
+  const calldata =
+    process.env.NEXT_PUBLIC_IS_TESTNET === "true"
+      ? [2, encodedDomain, rootDomain, 0]
+      : [2, encodedDomain, rootDomain];
   return {
     contractAddress: process.env.NEXT_PUBLIC_NAMING_CONTRACT as string,
     entrypoint: "set_address_to_domain",
-    calldata: [2, encodedDomain, rootDomain],
+    calldata,
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/starknet-id/app.starknet.id/issues/734#issuecomment-2063454477

Caused by a change to the naming contract where we added a hint array to `set_address_to_domain`, currently only live on sepolia at the moment. 