### PR TITLE
fix: getPfpFromVerifierData nft id conversion

### DIFF
--- a/utils/apiWrappers/identity.ts
+++ b/utils/apiWrappers/identity.ts
@@ -180,7 +180,7 @@ export class Identity {
     const id = this.getExtendedVerifierData(
       formatHexString(process.env.NEXT_PUBLIC_NFT_PP_VERIFIER as string),
       NFT_PP_ID
-    )?.map((hex) => BigInt(parseInt(hex, 16)));
+    )?.map((hex) => BigInt(hex));
 
     if (!id || !contractAddress || Number(contractAddress) === 0)
       return identiconsUrl;


### PR DESCRIPTION
This PR fixes a nft id conversion bug in `getPfpFromVerifierData` resulting in nft profile pic not showing on the identity page. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ID handling by directly converting hex to BigInt, enhancing performance and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->