### PR TITLE
fix: hiding address

### DIFF
--- a/components/identities/identityCard.tsx
+++ b/components/identities/identityCard.tsx
@@ -4,7 +4,6 @@ import {
   convertNumberToFixedLengthString,
   getDomainWithoutStark,
   getEnsFromStark,
-  minifyAddress,
   shortenDomain,
 } from "../../utils/stringService";
 import SocialMediaActions from "./actions/socialmediaActions";
@@ -18,7 +17,6 @@ import { debounce } from "../../utils/debounceService";
 import { Identity } from "../../utils/apiWrappers/identity";
 import PlusIcon from "../UI/iconsComponents/icons/plusIcon";
 import AddEvmAddrModal from "./actions/addEvmAddrModal";
-import CopyContent from "../UI/copyContent";
 
 type IdentityCardProps = {
   identity?: Identity;
@@ -123,13 +121,6 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
               <div className="flex flex-col">
                 {identity?.targetAddress ? (
                   <>
-                    <div className={styles.addressBar}>
-                      <h2>{minifyAddress(identity.targetAddress)}</h2>
-                      <CopyContent
-                        value={identity?.targetAddress}
-                        className="cursor-pointer ml-3"
-                      />
-                    </div>
                     <div className="flex flex-row items-center justify-center">
                       <div className={styles.starknetAddr}>
                         <h1 className={styles.domain}>

--- a/components/identities/identityCard.tsx
+++ b/components/identities/identityCard.tsx
@@ -4,6 +4,7 @@ import {
   convertNumberToFixedLengthString,
   getDomainWithoutStark,
   getEnsFromStark,
+  minifyAddress,
   shortenDomain,
 } from "../../utils/stringService";
 import SocialMediaActions from "./actions/socialmediaActions";
@@ -17,6 +18,7 @@ import { debounce } from "../../utils/debounceService";
 import { Identity } from "../../utils/apiWrappers/identity";
 import PlusIcon from "../UI/iconsComponents/icons/plusIcon";
 import AddEvmAddrModal from "./actions/addEvmAddrModal";
+import CopyContent from "../UI/copyContent";
 
 type IdentityCardProps = {
   identity?: Identity;
@@ -121,6 +123,15 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
               <div className="flex flex-col">
                 {identity?.targetAddress ? (
                   <>
+                    {identity?.domain ? (
+                      <div className={styles.addressBar}>
+                        <h2>{minifyAddress(identity.targetAddress)}</h2>
+                        <CopyContent
+                          value={identity?.targetAddress}
+                          className="cursor-pointer ml-3"
+                        />
+                      </div>
+                    ) : null}
                     <div className="flex flex-row items-center justify-center">
                       <div className={styles.starknetAddr}>
                         <h1 className={styles.domain}>


### PR DESCRIPTION
close: #800 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the `minifyAddress` function from the `IdentityCard` component, resulting in the full address being displayed in the UI instead of a shortened version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->