### PR TITLE
fix: force last version of starknetid.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react-icons": "^4.4.0",
         "react-loader-spinner": "5.4.5",
         "starknet": "^5.25.0",
-        "starknetid.js": "^3.2.0",
+        "starknetid.js": "^3.2.2",
         "starknetkit": "^1.1.3",
         "tldts": "^6.1.20",
         "twitter-api-sdk": "^1.2.1"
@@ -18237,9 +18237,9 @@
       }
     },
     "node_modules/starknetid.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/starknetid.js/-/starknetid.js-3.2.0.tgz",
-      "integrity": "sha512-I0gJlNegP+DO3JPjSSfUdflqPah6oUoIUBMl33h1JMwrWSfVA+cPajze7fwRg2xNuJOadI2eeMWI7Q+OdLa+rg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/starknetid.js/-/starknetid.js-3.2.2.tgz",
+      "integrity": "sha512-nwHpuMXGFIKQq8ghwIe6I6qZHTj1vnlab/252LctsnnnKl5sC6BJgkBR42MsgddV5xJUGr9YwpVcZAWX9QS0Lw==",
       "engines": {
         "node": ">=16"
       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-icons": "^4.4.0",
     "react-loader-spinner": "5.4.5",
     "starknet": "^5.25.0",
-    "starknetid.js": "^3.2.0",
+    "starknetid.js": "^3.2.2",
     "starknetkit": "^1.1.3",
     "tldts": "^6.1.20",
     "twitter-api-sdk": "^1.2.1"


### PR DESCRIPTION
Close #835 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `starknetid.js` library version to `^3.2.2` for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->