### PR TITLE
ref: identity warnings

### DIFF
--- a/components/identities/identitiesGalleryV1.tsx
+++ b/components/identities/identitiesGalleryV1.tsx
@@ -59,7 +59,8 @@ const IdentitiesGalleryV1: FunctionComponent<IdentitiesGalleryV1Props> = ({
             className={styles.imageGallery}
             onClick={() => router.push(`/identities/${identity.id}`)}
           >
-            {isIdentityExpiringSoon(identity) ? (
+            {needAutoRenewal?.includes(identity.domain) &&
+            isIdentityExpiringSoon(identity) ? (
               <div className={styles.expiryWarning}>
                 <Tooltip
                   title={


### PR DESCRIPTION
<img width="345" alt="Capture d’écran 2024-09-23 à 15 35 16" src="https://github.com/user-attachments/assets/ce7e0f8e-496e-4c51-8931-dee431b5b698">

Domain is subscribed but we still show the warning so I fixed it 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced expiry warning logic in the Identities Gallery, now requiring both imminent expiry and domain inclusion in the auto-renewal list for display. 

- **Bug Fixes**
	- Improved accuracy of expiry warnings, ensuring users receive timely notifications based on updated conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->