### PR TITLE
Fix the weight of first section

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -3,12 +3,16 @@
   position: relative;
   margin-top: 12vh;
   overflow: auto;
+  display: flex;
+  justify-content: center;
 }
 
 .wrapperScreen {
   display: inline-flex;
   flex-direction: column;
   width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
   justify-content: center;
   height: calc(100% - 12vh);
 }


### PR DESCRIPTION
Close: #1017 

Added a 1440px constraint to /pages/index.tsx by updating /styles/Home.module.css from
```
.screen {
  height: 88vh;
  position: relative;
  margin-top: 12vh;
  overflow: auto;
}

.wrapperScreen {
  display: inline-flex;
  flex-direction: column;
  width: 100%;
  justify-content: center;
  height: calc(100% - 12vh);
}
```
to
```
.screen {
  height: 88vh;
  position: relative;
  margin-top: 12vh;
  overflow: auto;
  display: flex;
  justify-content: center;
}

.wrapperScreen {
  display: inline-flex;
  flex-direction: column;
  width: 100%;
  max-width: 1440px;
  margin: 0 auto;
  justify-content: center;
  height: calc(100% - 12vh);
}
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the homepage layout for improved responsiveness.
	- Child elements are now centered horizontally for a cleaner design.
	- The main container’s width is confined and centrally positioned for better visual structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->