### PR TITLE
Fix: Refonted Renew your domain - Second step "Checkout"

### DIFF
--- a/components/UI/inputHelper.tsx
+++ b/components/UI/inputHelper.tsx
@@ -1,5 +1,7 @@
 import React, { FunctionComponent, ReactNode } from "react";
-
+import InfoIcon from "./iconsComponents/icons/infoIcon";
+import StyledToolTip from "./styledTooltip";
+import theme from "../../styles/theme";
 
 type InputHelperProps = {
   children: ReactNode;
@@ -10,15 +12,25 @@ type InputHelperProps = {
 const InputHelper: FunctionComponent<InputHelperProps> = ({
   children,
   helperText,
+  error = false,
 }) => {
   return (
     <div className="relative">
       {children}
-      {helperText && (
-       <div className="text-sm text-gray-500 mt-1">         
-       {helperText}
-      </div>
-    )}
+      {helperText ? (
+        <StyledToolTip
+          className="cursor-pointer"
+          title={helperText}
+          placement="top"
+        >
+          <div className="absolute top-1/2 -translate-y-1/2 right-2">
+            <InfoIcon
+              width="20px"
+              color={error ? "red" : theme.palette.grey[800]}
+            />
+          </div>
+        </StyledToolTip>
+      ) : null}
     </div>
   );
 };

--- a/components/domains/steps/upsellCard.tsx
+++ b/components/domains/steps/upsellCard.tsx
@@ -66,7 +66,7 @@ const UpsellCard: FunctionComponent<UpsellCardProps> = ({
           <FormControlLabel
             control={<Radio />}
             value={false}
-            label={<p className={textFieldStyles.legend}>No, thanks!</p>}
+            label={<p className={textFieldStyles.legend}>No, thanks</p>}
           />
         </div>
       </RadioGroup>

--- a/styles/components/registerV2.module.css
+++ b/styles/components/registerV2.module.css
@@ -120,7 +120,10 @@
 
 .totalDueTitle {
   /* Body/normal/bold */
-  font-family: "Poppins-Bold";
+  font-family: "Poppins-bold";
+  font-style: normal;
+  font-weight: 300;
+  color: #454545;
   font-size: 20px;
   line-height: 24px; /* 120% */
   letter-spacing: 0.2px;

--- a/styles/components/registerV3.module.css
+++ b/styles/components/registerV3.module.css
@@ -188,9 +188,9 @@
 }
 
 .totalDueTitle {
-  font-family: "Poppins-Bold";
-  font-size: 20px;
   font-weight: 500;
+  color: #454545;
+  font-size: 20px;
   line-height: 24px; /* 120% */
   letter-spacing: 0.2px;
 }

--- a/styles/components/textField.module.css
+++ b/styles/components/textField.module.css
@@ -25,7 +25,7 @@
 .legend {
   color: var(--secondary);
   /* Body/small/medium */
-  font-size: 18px;
+  font-size: 16px;
   font-style: normal;
   font-weight: 400;
   line-height: 20px;

--- a/styles/components/upsellCard.module.css
+++ b/styles/components/upsellCard.module.css
@@ -57,9 +57,11 @@
 }
 
 .radioGroupContainer {
+  background-color: white;
   width: 100%;
   border: 1px solid #45454533;
   border-radius: 8px;
+  box-shadow: 0px 2px 50px rgba(0, 0, 0, 0.06);
   padding: 8px 20px;
 }
 

--- a/styles/components/upsellCard.module.css
+++ b/styles/components/upsellCard.module.css
@@ -61,7 +61,7 @@
   width: 100%;
   border: 1px solid #45454533;
   border-radius: 8px;
-  box-shadow: 0px 2px 50px rgba(0, 0, 0, 0.06);
+  box-shadow: 0px 2px 30px rgba(0, 0, 0, 0.06);
   padding: 8px 20px;
 }
 
@@ -141,6 +141,10 @@
   .legend {
     font-size: 10px;
     letter-spacing: -0.3px;
+  }
+
+  .radioGroupContainer{
+    box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.06);
   }
 }
 

--- a/styles/components/upsellCard.module.css
+++ b/styles/components/upsellCard.module.css
@@ -159,4 +159,8 @@
     font-size: 9px;
     letter-spacing: -0.4px;
   }
+
+  .radioGroupContainer{
+    box-shadow: 0px 1px 10px rgba(0, 0, 0, 0.06);
+  }
 }

--- a/utils/discounts/evergreen.ts
+++ b/utils/discounts/evergreen.ts
@@ -8,7 +8,7 @@ export const renewal: Upsell = {
     desc: "Unlock Extended Domain",
     catch: "3 Years for the Price of 2!",
   },
-  desc: "Don't miss out on this one-time offer! This is your chance to secure extended benefits and ensure a lasting digital presence.",
+  desc: "Take advantage of this exclusive offer! Secure your domain for three years at the price of two years.",
 };
 
 export const registration: Upsell = {
@@ -21,7 +21,7 @@ export const registration: Upsell = {
     desc: "Unlock Extended Domain",
     catch: "3 Years for the Price of 2!",
   },
-  desc: "Don't miss out on this one-time offer! This is your chance to secure extended benefits and ensure a lasting digital presence.",
+  desc: "Take advantage of this exclusive offer! Secure your domain for three years at the price of two years.",
 };
 
 const evergreenDiscounts = {


### PR DESCRIPTION
### Close #963 

This PR correctly refonts and fixes bug in the `Renew your domain` section

### Summary

-  Modified the `regiterV3.module.css` , `regiterV2.module.css`, `upsellCard.module.css` and `textField.module.css` pages to match the desired styles in the design
- Modified the desc text in the `evergreen.ts` file to match that in the design.
- Modified the `inputHelper.tsx` file to include the `StyledToolTip` function in the `styleToolTip.tsx` file. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced input field guidance: helper text now appears as an interactive tooltip.
  - Updated promotional messaging to emphasize extended domain registration benefits.

- **Style**
  - Refined text styling across registration and input components for improved readability.
  - Adjusted option display with a subtler label.
  - Improved visual consistency of the upsell card with new background and shadow effects.
  - Modified text appearance in various components with updated font styles and colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->