### PR TITLE
Fix: Align domain search elements vertically #1049

### DIFF
--- a/components/identities/identityCard.tsx
+++ b/components/identities/identityCard.tsx
@@ -45,7 +45,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
   return (
     <div className={styles.wrapper}>
       <div className={styles.container}>
-        <div className="lg:mt-10 flex items-center lg:justify-between justify-center sm:text-center gap-3 sm:gap-5 my-2 flex-wrap lg:flex-row sm:flex-col">
+        <div className="lg:mt-10 flex-col flex items-center lg:justify-between justify-center sm:text-center gap-3 sm:gap-5 my-2 flex-wrap lg:flex-row sm:flex-col">
           <div className="my-2 text-center">
             <div
               className={styles.pfpSection}

--- a/components/identities/identityCard.tsx
+++ b/components/identities/identityCard.tsx
@@ -43,7 +43,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
   const minting = searchParams.get("minting") === "true";
 
   return (
-    <div  className={styles.wrapper}>
+    <div className={styles.wrapper}>
       <div className={styles.container}>
         <div className="lg:mt-10 flex-col flex items-center lg:justify-between justify-center sm:text-center gap-3 sm:gap-5 my-2 flex-wrap lg:flex-row sm:flex-col">
           <div className="my-2 text-center">
@@ -199,10 +199,12 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
         </div>
       </div>
       <div className={styles.cardCode}>
-        <p>{convertNumberToFixedLengthString(tokenId)}</p>
+        <p className="text-sm sm:text-[18px]">
+          <span className="sm:hidden  min-w-[max-content]">{convertNumberToFixedLengthString(tokenId).slice(0, 7)}</span>
+          <span className="hidden sm:inline">{convertNumberToFixedLengthString(tokenId)}</span>
+        </p>
         <svg
-         className="mb-[10px] sm:mb-0"
-          width="300"
+          className="w-full min-w-[10px] sm:w-[200px] sm:mb-0"
           height="6"
           viewBox="0 0 380 6"
           fill="none"

--- a/components/identities/identityCard.tsx
+++ b/components/identities/identityCard.tsx
@@ -199,12 +199,11 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
         </div>
       </div>
       <div className={styles.cardCode}>
-        <p className="text-sm sm:text-[18px]">
-          <span className="sm:hidden  min-w-[max-content]">{convertNumberToFixedLengthString(tokenId).slice(0, 7)}</span>
-          <span className="hidden sm:inline">{convertNumberToFixedLengthString(tokenId)}</span>
+        <p>
+          <span >{convertNumberToFixedLengthString(tokenId)}</span>
         </p>
         <svg
-          className="w-full min-w-[10px] sm:w-[200px] sm:mb-0"
+          className="w-full hidden sm:block sm:w-[200px] md:w-[300px]"
           height="6"
           viewBox="0 0 380 6"
           fill="none"

--- a/components/identities/identityCard.tsx
+++ b/components/identities/identityCard.tsx
@@ -43,7 +43,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
   const minting = searchParams.get("minting") === "true";
 
   return (
-    <div className={styles.wrapper}>
+    <div  className={styles.wrapper}>
       <div className={styles.container}>
         <div className="lg:mt-10 flex-col flex items-center lg:justify-between justify-center sm:text-center gap-3 sm:gap-5 my-2 flex-wrap lg:flex-row sm:flex-col">
           <div className="my-2 text-center">
@@ -201,6 +201,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
       <div className={styles.cardCode}>
         <p>{convertNumberToFixedLengthString(tokenId)}</p>
         <svg
+         className="mb-[10px] sm:mb-0"
           width="300"
           height="6"
           viewBox="0 0 380 6"

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -79,8 +79,11 @@ const SearchPage: NextPage = () => {
 
   return (
     <div className={homeStyles.screen}>
-      <div className={styles.container}>
-        <div className="sm:w-2/5 w-4/5 mb-5 mt-2">
+      <div style={{
+        justifyContent:"start",
+        padding:'1rem'
+      }} className={styles.container}>
+        <div className="sm:w-3/5 md:w-2/5 w-4/5 mb-5 mt-2 ">
           <SearchBar
             onChangeTypedValue={(typeValue: string) => setDomain(typeValue)}
             showHistory={false}

--- a/styles/components/identityCard.module.css
+++ b/styles/components/identityCard.module.css
@@ -80,7 +80,7 @@
 .cardCode {
   /* Placement */
   background-color: var(--background-white);
-  height: 83px;
+  min-height: 83px;
   width: 650px;
   max-width: 650px;
   border-width: 0px 6px 4px 2px;
@@ -90,6 +90,7 @@
   border-bottom-left-radius: 30px;
   margin-top: -1px;
   z-index: 10;
+  flex-wrap: wrap; 
 
   /* Inside */
   display: flex;
@@ -102,6 +103,11 @@
   line-height: 32px;
   letter-spacing: 0.8em;
   color: var(--identity-card-footer-text);
+}
+
+.cardCode p {
+  word-break: break-word; 
+  overflow-wrap: break-word; 
 }
 
 .identityCardSkeleton {

--- a/styles/components/identityCard.module.css
+++ b/styles/components/identityCard.module.css
@@ -101,6 +101,7 @@
   font-size: 18px;
   line-height: 32px;
   letter-spacing: 0.8em;
+  text-indent: 0.9em;
   color: var(--identity-card-footer-text);
 }
 
@@ -362,5 +363,4 @@
     padding-bottom: 0;
   }
 }
-
 

--- a/styles/components/identityCard.module.css
+++ b/styles/components/identityCard.module.css
@@ -90,7 +90,6 @@
   border-bottom-left-radius: 30px;
   margin-top: -1px;
   z-index: 10;
-  flex-wrap: wrap; 
 
   /* Inside */
   display: flex;
@@ -103,11 +102,6 @@
   line-height: 32px;
   letter-spacing: 0.8em;
   color: var(--identity-card-footer-text);
-}
-
-.cardCode p {
-  word-break: break-word; 
-  overflow-wrap: break-word; 
 }
 
 .identityCardSkeleton {
@@ -368,3 +362,5 @@
     padding-bottom: 0;
   }
 }
+
+


### PR DESCRIPTION
Aligned elements of the domain card vertically according to the new Figma design.
Tested locally to ensure correct layout.
Close #1049.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the layout of the identity card component for improved content presentation.
  - Modified the search page layout for better spacing and alignment.

- **Style**
  - Improved text handling with responsive behavior for displaying the token ID in the identity card component.
  - Adjusted the minimum height for the identity card component to allow for flexible content sizing.
  - Updated the search bar's width for better responsiveness on small screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->