### PR TITLE
Fix: Change the color of the date chip

### DIFF
--- a/components/identities/identityCard.tsx
+++ b/components/identities/identityCard.tsx
@@ -45,7 +45,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
   return (
     <div className={styles.wrapper}>
       <div className={styles.container}>
-        <div className="lg:mt-10 flex-col flex items-center lg:justify-between justify-center sm:text-center gap-3 sm:gap-5 my-2 flex-wrap lg:flex-row sm:flex-col">
+        <div className="flex flex-col flex-wrap items-center justify-center gap-3 my-2 lg:mt-10 lg:justify-between sm:text-center sm:gap-5 lg:flex-row sm:flex-col">
           <div className="my-2 text-center">
             <div
               className={styles.pfpSection}
@@ -95,9 +95,28 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
             </div>
             {identity?.domainExpiry ? (
               <Tooltip title="Expiry date of this domain" arrow>
-                <div className={styles.expiryContainer}>
-                  <CalendarIcon width="16" color={theme.palette.primary.main} />
-                  <p className={styles.expiryText}>
+                <div
+                  className={
+                    new Date(identity.domainExpiry * 1000) < new Date()
+                      ? styles.expiryContainer // Expired (red)
+                      : styles.notExpiryContainer // Not expired (green)
+                  }
+                >
+                  <CalendarIcon
+                    width="16"
+                    color={
+                      new Date(identity.domainExpiry * 1000) < new Date()
+                        ? styles.expiryContainerIcon // Red for expired
+                        : theme.palette.primary.main // Green for active
+                    }
+                  />
+                  <p
+                    className={
+                      new Date(identity.domainExpiry * 1000) < new Date()
+                        ? styles.expiryText // Red for expired text
+                        : styles.notExpiryText // Green for active text
+                    }
+                  >
                     {timestampToReadableDate(identity.domainExpiry)}
                   </p>
                 </div>
@@ -105,7 +124,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
             ) : null}
           </div>
           {minting ? (
-            <div className="text-left h-full py-2">
+            <div className="h-full py-2 text-left">
               <h1 className="text-3xl font-bold font-quickZap">
                 Minting your identity...
               </h1>
@@ -134,7 +153,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
                               <h2>{minifyAddress(identity.targetAddress)}</h2>
                               <CopyContent
                                 value={identity?.targetAddress}
-                                className="cursor-pointer ml-3"
+                                className="ml-3 cursor-pointer"
                               />
                             </div>
                           ) : null}
@@ -150,7 +169,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
                               <h2>{minifyAddress(identity.targetAddress)}</h2>
                               <CopyContent
                                 value={identity?.targetAddress}
-                                className="cursor-pointer ml-3"
+                                className="ml-3 cursor-pointer"
                               />
                             </div>
                           ) : null}
@@ -200,7 +219,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
       </div>
       <div className={styles.cardCode}>
         <p>
-          <span >{convertNumberToFixedLengthString(tokenId)}</span>
+          <span>{convertNumberToFixedLengthString(tokenId)}</span>
         </p>
         <svg
           className="w-full hidden sm:block sm:w-[200px] md:w-[300px]"

--- a/components/identities/identityCard.tsx
+++ b/components/identities/identityCard.tsx
@@ -41,6 +41,9 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
   const handleMouseLeave = debounce(() => setIsHovered(false), 50);
   const searchParams = useSearchParams();
   const minting = searchParams.get("minting") === "true";
+  const isDomainExpired = identity?.domainExpiry
+    ? new Date(identity.domainExpiry * 1000) < new Date()
+    : false;
 
   return (
     <div className={styles.wrapper}>
@@ -97,7 +100,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
               <Tooltip title="Expiry date of this domain" arrow>
                 <div
                   className={
-                    new Date(identity.domainExpiry * 1000) < new Date()
+                    isDomainExpired
                       ? styles.expiryContainer // Expired (red)
                       : styles.notExpiryContainer // Not expired (green)
                   }
@@ -105,14 +108,14 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
                   <CalendarIcon
                     width="16"
                     color={
-                      new Date(identity.domainExpiry * 1000) < new Date()
+                      isDomainExpired
                         ? styles.expiryContainerIcon // Red for expired
                         : theme.palette.primary.main // Green for active
                     }
                   />
                   <p
                     className={
-                      new Date(identity.domainExpiry * 1000) < new Date()
+                      isDomainExpired
                         ? styles.expiryText // Red for expired text
                         : styles.notExpiryText // Green for active text
                     }

--- a/components/identities/identityCard.tsx
+++ b/components/identities/identityCard.tsx
@@ -109,7 +109,7 @@ const IdentityCard: FunctionComponent<IdentityCardProps> = ({
                     width="16"
                     color={
                       isDomainExpired
-                        ? styles.expiryContainerIcon // Red for expired
+                        ? theme.palette.error.main // Red for expired
                         : theme.palette.primary.main // Green for active
                     }
                   />

--- a/styles/components/identityCard.module.css
+++ b/styles/components/identityCard.module.css
@@ -133,7 +133,7 @@
 }
 
 .expiryContainerIcon {
-  color: #d32f2f;
+  color: var(--negative);
 }
 
 .notExpiryContainer {
@@ -151,7 +151,7 @@
 }
 
 .expiryText {
-  color: var(--primary-700, #454545);
+  color: var(--secondary);
   text-align: center;
 
   /* Body/micro/medium */
@@ -162,7 +162,7 @@
 }
 
 .notExpiryText {
-  color: var(--primary-700, #000);
+  color: var(--black);
   text-align: center;
 
   /* Body/micro/medium */

--- a/styles/components/identityCard.module.css
+++ b/styles/components/identityCard.module.css
@@ -126,6 +126,24 @@
   gap: 8px;
   border-radius: 8px;
   margin-top: 8px;
+  background: var(--primary-700, #f6d5d5);
+
+  /* Small Shadow */
+  box-shadow: 0px 2px 30px 0px rgba(0, 0, 0, 0.06);
+}
+
+.expiryContainerIcon {
+  color: "#D32F2F";
+}
+
+.notExpiryContainer {
+  display: inline-flex;
+  padding: 4px 8px;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  border-radius: 8px;
+  margin-top: 8px;
   background: var(--primary-700, #dcf2e9);
 
   /* Small Shadow */
@@ -133,6 +151,17 @@
 }
 
 .expiryText {
+  color: var(--primary-700, #454545);
+  text-align: center;
+
+  /* Body/micro/medium */
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 16px; /* 133.333% */
+}
+
+.notExpiryText {
   color: var(--primary-700, #000);
   text-align: center;
 
@@ -363,4 +392,3 @@
     padding-bottom: 0;
   }
 }
-

--- a/styles/components/identityCard.module.css
+++ b/styles/components/identityCard.module.css
@@ -126,7 +126,7 @@
   gap: 8px;
   border-radius: 8px;
   margin-top: 8px;
-  background: var(--primary-700, #f6d5d5);
+  background: var(--negative-light);
 
   /* Small Shadow */
   box-shadow: 0px 2px 30px 0px rgba(0, 0, 0, 0.06);
@@ -140,7 +140,7 @@
   gap: 8px;
   border-radius: 8px;
   margin-top: 8px;
-  background: var(--primary-700, #dcf2e9);
+  background: var(--primary300);
 
   /* Small Shadow */
   box-shadow: 0px 2px 30px 0px rgba(0, 0, 0, 0.06);

--- a/styles/components/identityCard.module.css
+++ b/styles/components/identityCard.module.css
@@ -133,7 +133,7 @@
 }
 
 .expiryContainerIcon {
-  color: "#D32F2F";
+  color: #d32f2f;
 }
 
 .notExpiryContainer {

--- a/styles/components/identityCard.module.css
+++ b/styles/components/identityCard.module.css
@@ -132,10 +132,6 @@
   box-shadow: 0px 2px 30px 0px rgba(0, 0, 0, 0.06);
 }
 
-.expiryContainerIcon {
-  color: var(--negative);
-}
-
 .notExpiryContainer {
   display: inline-flex;
   padding: 4px 8px;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -34,6 +34,7 @@
   --dark-content: #454545;
   --content600: #8c8989;
   --negative: #d32f2f;
+  --negative-light: #f6d5d5;
   --black: #000000;
   --identity-card-footer-text: #e2dfde;
   --identity-card-border-color: #293e28;

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -17,6 +17,10 @@ const theme = createTheme({
       200: "#CDCCCC",
       800: "#454545",
     },
+    error: {
+      main: "#d32f2f",
+      light: "#f6d5d5",
+    },
   },
 });
 


### PR DESCRIPTION
I changed the color of the 'date chip' to red when the domain expired. I kept it green as it is currently when the domain has not yet expired.
close: #1026 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- The identity card now displays domain expiry information with dynamic visual cues that clearly differentiate active and expired domains.

- **Style**
	- Enhanced styling updates improve the display of expiry details, including new classes for the expiry container and icon, as well as updated text styles for better visual clarity.
	- Introduced a new error color palette for consistent representation of error states throughout the application.
	- Added a new CSS variable for improved theming options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->