### PR TITLE
Feat: Added Activate subscription button when subscription is inactive

### DIFF
--- a/components/identities/actions/identityActions.tsx
+++ b/components/identities/actions/identityActions.tsx
@@ -28,6 +28,7 @@ import PyramidIcon from "../../UI/iconsComponents/icons/pyramidIcon";
 import { StarknetIdJsContext } from "@/context/StarknetIdJsProvider";
 import RenewalIcon from "@/components/UI/iconsComponents/icons/renewalIcon";
 import ActiveSubscriptionCard from "./ActiveSubscriptionCard";
+import Button from "@/components/UI/button";
 
 type IdentityActionsProps = {
   identity?: Identity;
@@ -317,6 +318,11 @@ const IdentityActions: FunctionComponent<IdentityActionsProps> = ({
                         aria-label="Inactive subscription information"
                       >
                         {/* Content for subscription */}
+                        <Button
+                          onClick={() => router.push("/subscription")}
+                        >
+                          Activate subscription
+                        </Button>
                       </div>
                     )}
 


### PR DESCRIPTION
- Close: #1095 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a button for main domains with inactive subscriptions, allowing users to navigate directly to the subscription page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->